### PR TITLE
Add service name tag to web service ELBs

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -152,6 +152,8 @@ Resources:
                 Effect: "Allow"
                 Action: 
                   - servicediscovery:DiscoverInstances
+                  - elasticloadbalancing:DescribeLoadBalancers
+                  - elasticloadbalancing:DescribeTags
                 Resource: "*"       
               - 
                 Effect: "Allow"
@@ -175,6 +177,8 @@ Resources:
                 Action: 
                   - mobiletargeting:*
                   - iam:GetRole
+                  - elasticloadbalancing:DescribeLoadBalancers
+                  - elasticloadbalancing:DescribeTags
                 Resource: "*"
               - 
                 Effect: "Allow"

--- a/aws/cloudformation-templates/services/service/_template.yaml
+++ b/aws/cloudformation-templates/services/service/_template.yaml
@@ -180,6 +180,7 @@ Resources:
     Properties:
       TemplateURL: !Sub https://s3.amazonaws.com/${ResourceBucket}/${ResourceBucketRelativePath}cloudformation-templates/services/service/loadbalancer.yaml
       Parameters:
+        ServiceName: !Ref ServiceName
         Subnets: !Ref Subnets
         VpcId: !Ref VpcId
 

--- a/aws/cloudformation-templates/services/service/loadbalancer.yaml
+++ b/aws/cloudformation-templates/services/service/loadbalancer.yaml
@@ -5,6 +5,8 @@ Description: >
     This template deploys A Retail Demo Store Service Load Balancer.
 
 Parameters:
+  ServiceName:
+    Type: String
 
   Subnets:
     Type: List<AWS::EC2::Subnet::Id>
@@ -30,6 +32,10 @@ Resources:
       Subnets: !Ref Subnets
       SecurityGroups:
         - !Ref SecurityGroup
+      Tags:
+        -
+          Key: RetailDemoStoreServiceName
+          Value: !Ref ServiceName
 
   LoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener


### PR DESCRIPTION
*Issue #, if available:*

Closes #19 

*Description of changes:*

To make it easier to look up load balancer DNS names for web services in workshop notebooks, add a tag to each ELB with the service name and give notebooks permissions to lookup tags. For example, for the Braze workshop we need to instruct the user to update the Braze Connected Content URL in the email template with the public URL to the recommendations service. With this change, we can lookup the DNS name for the ELB and display it to the user rather than forcing them to hunt around in the console for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
