### PR TITLE
Copy missing public read ACL

### DIFF
--- a/src/aws-lambda/elasticsearch-pre-index/stage.sh
+++ b/src/aws-lambda/elasticsearch-pre-index/stage.sh
@@ -13,7 +13,7 @@ fi
 source ./bundle.sh
 
 echo "Staging bundle to S3"
-aws s3 cp ${PACKAGE_FILE} s3://${S3_BUCKET}/${S3_PATH}aws-lambda/${PACKAGE_FILE}
+aws s3 cp ${PACKAGE_FILE} s3://${S3_BUCKET}/${S3_PATH}aws-lambda/${PACKAGE_FILE} $S3PUBLIC
 
 echo "Uploading products.yaml to S3"
 aws s3 cp ../../../src/products/src/products-service/data/products.yaml s3://${S3_BUCKET}/${S3_PATH}data/products.yaml $S3PUBLIC


### PR DESCRIPTION
*Description of changes:*

The read ACL CLI param was missing for the ES lambda function which caused permissions errors during stack deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
