### PR TITLE
Add AWS_DEFAULT_REGION environment variable

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -4,6 +4,7 @@
 APPDATA=/tmp
 
 AWS_REGION=us-west-2
+AWS_DEFAULT_REGION=us-west-2
 
 # Product service variables:
 # DynamoDB table names

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     container_name: products
     environment:
       - AWS_REGION
+      - AWS_DEFAULT_REGION
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
@@ -44,6 +45,7 @@ services:
       - products
     environment:
       - AWS_PROFILE
+      - AWS_DEFAULT_REGION
       - PRODUCT_SERVICE_HOST
       - PRODUCT_SERVICE_PORT
     volumes:


### PR DESCRIPTION
boto3 seems to look for this for the default region according to [docs](https://github.com/boto/boto3/blob/959bc56ead8640feb665b828c0f548194a9c4eb7/docs/source/guide/configuration.rst#using-environment-variables)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.