### PR TITLE
Change order of recommendations service Dockerfile steps

### DIFF
--- a/src/recommendations/Dockerfile
+++ b/src/recommendations/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.8-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y g++
 COPY /src/recommendations-service/requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
*Description of changes:*
This prevents running `apt-get update && apt-get install -y g++ git` and `pip install -r requirements.txt` unless there were a change to `requirements.txt`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
