### PR TITLE
resource_bucket_path in CopyImagesLambdaFunction

### DIFF
--- a/aws/cloudformation-templates/web-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/web-ui-pipeline.yaml
@@ -130,6 +130,7 @@ Resources:
               source_bucket_name = event['ResourceProperties']['SourceBucket']
               source_path = event['ResourceProperties']['SourceBucketPath']
               target_bucket_name = event['ResourceProperties']['TargetBucket']
+              resource_bucket_path = event['ResourceProperties']['ResourceBucketRelativePath']
 
               if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
                 # Copy from source to target
@@ -139,7 +140,11 @@ Resources:
 
                 for obj in source_bucket.objects.filter(Prefix=source_path):
                     source = { 'Bucket': source_bucket_name, 'Key': obj.key }
-                    target = target_bucket.Object(obj.key)
+                    if len(resource_bucket_path)>0:
+                      # need to remove the resource_relative_path for the target images directory
+                      target = target_bucket.Object(obj.key[len(resource_bucket_path):])
+                    else:
+                      target = target_bucket.Object(obj.key)
                     target.copy(source)
 
                 response_data['Message'] = "Resource creation succeeded"
@@ -165,6 +170,7 @@ Resources:
       SourceBucket: !Ref ResourceBucket
       SourceBucketPath: !Sub '${ResourceBucketRelativePath}images'
       TargetBucket: !Ref WebUIBucketName
+      ResourceBucketRelativePath: !Ref ResourceBucketRelativePath
 
   CopyImagesLambdaExecutionRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Issue #, if available: #80 

Description of changes:
changed CopyImagesLambdaFunction to copy the images from sourcebucket/resourcebucket/images to targetbucket/images to match the rest of the configurations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
