### PR TITLE
Cache campaign and solution version details

### DIFF
--- a/src/recommendations/src/recommendations-service/app.py
+++ b/src/recommendations/src/recommendations-service/app.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 from experimentation.experiment_manager import ExperimentManager
 from experimentation.resolvers import DefaultProductResolver, PersonalizeRecommendationsResolver, PersonalizeRankingResolver, RankingProductsNoOpResolver
 from experimentation.utils import CompatEncoder
+from expiring_dict import ExpiringDict
 
 import json
 import os, sys
@@ -14,6 +15,11 @@ import pprint
 import boto3
 import logging
 import requests
+
+# Since the DescribeCampaign API easily throttles and we just need
+# the recipe from the campaign and it won't change often (if at all), 
+# use a cache to help smooth out periods where we get throttled.
+personalize_meta_cache = ExpiringDict(2 * 60 * 60)
 
 servicediscovery = boto3.client('servicediscovery')
 personalize = boto3.client('personalize')
@@ -27,12 +33,25 @@ filter_purchased_param_name = 'retaildemostore-personalize-filter-purchased-arn'
 def get_recipe(campaign_arn):
     """ Returns the Amazon Personalize recipe ARN for the specified campaign ARN """
     recipe = None
-    response = personalize.describe_campaign(campaignArn = campaign_arn)
 
-    if response.get('campaign'):
-        response = personalize.describe_solution_version(solutionVersionArn = response['campaign']['solutionVersionArn'])
-        if response.get('solutionVersion'):
-            recipe = response['solutionVersion']['recipeArn']
+    campaign = personalize_meta_cache.get(campaign_arn)
+    if not campaign:
+        response = personalize.describe_campaign(campaignArn = campaign_arn)
+        if response.get('campaign'):
+            campaign = response['campaign']
+            personalize_meta_cache[campaign_arn] = campaign
+
+    if campaign:
+        solution_version = personalize_meta_cache.get(campaign['solutionVersionArn'])
+
+        if not solution_version:
+            response = personalize.describe_solution_version(solutionVersionArn = campaign['solutionVersionArn'])
+            if response.get('solutionVersion'):
+                solution_version = response['solutionVersion']
+                personalize_meta_cache[campaign['solutionVersionArn']] = solution_version
+
+        if solution_version:
+            recipe = solution_version['recipeArn']
 
     return recipe
 

--- a/src/recommendations/src/recommendations-service/requirements.txt
+++ b/src/recommendations/src/recommendations-service/requirements.txt
@@ -4,3 +4,4 @@ boto3==1.14.53
 flask-cors==3.0.8
 numpy==1.18.1
 optimizely-sdk==3.5.2
+expiring-dict==1.1.0


### PR DESCRIPTION
*Description of changes:*

While doing some load testing against the Recommendations service, received several throttle exceptions for the DescribeCampaign API for Personalize. This API is called to retrieve the Personalize recipe for a campaign so it can be displayed in the UI. Since this value doesn't change often (if at all runtime), added a caching strategy that will reduce the number of API calls to Personalize and improve response time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
