### PR TITLE
BugFix: Update csv path

### DIFF
--- a/aws/cloudformation-templates/deployment-support.yaml
+++ b/aws/cloudformation-templates/deployment-support.yaml
@@ -121,7 +121,7 @@ Resources:
       Environment:
         Variables:
           csv_bucket: !Ref ResourceBucket
-          csv_path: 'csvs/'
+          csv_path: !Sub '${ResourceBucketRelativePath}csvs/'
           lambda_event_rule_name: 'RetailDemoStore-PersonalizePreCreateScheduledRule'
           Uid: !Ref Uid
 


### PR DESCRIPTION
When using RelativeResourceBucketPath, the CSV files are not written into the root of the bucket but under the ResourceBucketRelativePath. Fixing path with this commit

*Issue #, if available:*




*Description of changes:*
When using RelativeResourceBucketPath, the CSV files are not written into the root of the bucket but under the ResourceBucketRelativePath. Users deploying with a RelativeResourceBucketPath would face error in the Lambda function to precreate personalize campaign without this change.
Fixing the file  path with this commit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
