### PR TITLE
Recommendations service performance improvement

### DIFF
--- a/src/recommendations/src/recommendations-service/experimentation/experiment_manager.py
+++ b/src/recommendations/src/recommendations-service/experimentation/experiment_manager.py
@@ -35,14 +35,14 @@ class ExperimentManager:
         """ Returns True if this environment is setup for running experiments """
         return self.__get_table()
 
-    def is_optimizey_configured(self):
+    def is_optimizely_configured(self):
         return optimizely_configured
 
     def get_active(self, feature):
         """ Returns the active experiment for the given feature """
         experiment = None
 
-        if self.is_optimizey_configured():
+        if self.is_optimizely_configured():
             config = optimizely_sdk.get_optimizely_config()
             if config:
                 if feature in config.features_map:

--- a/src/recommendations/src/recommendations-service/experimentation/experiment_manager.py
+++ b/src/recommendations/src/recommendations-service/experimentation/experiment_manager.py
@@ -8,7 +8,7 @@ from boto3.dynamodb.conditions import Key
 from experimentation.experiment_ab import ABExperiment
 from experimentation.experiment_interleaving import InterleavingExperiment
 from experimentation.experiment_mab import MultiArmedBanditExperiment
-from experimentation.experiment_optimizely import OptimizelyFeatureTest, optimizely_sdk
+from experimentation.experiment_optimizely import OptimizelyFeatureTest, optimizely_sdk, optimizely_configured
 from experimentation.tracking import KinesisTracker
 
 log = logging.getLogger(__name__)
@@ -35,25 +35,29 @@ class ExperimentManager:
         """ Returns True if this environment is setup for running experiments """
         return self.__get_table()
 
+    def is_optimizey_configured(self):
+        return optimizely_configured
+
     def get_active(self, feature):
         """ Returns the active experiment for the given feature """
         experiment = None
 
-        config = optimizely_sdk.get_optimizely_config()
-        if config:
-            if feature in config.features_map:
-                optimizely_feature = config.features_map[feature]
-                experiment_keys = optimizely_feature.experiments_map.keys()
-                if len(experiment_keys) > 0:
-                    experiment_key = list(experiment_keys)[0]
-                    experiment = optimizely_feature.experiments_map[experiment_key]
-                    data = {'id': experiment.id,
-                            'feature': feature,
-                            'name': experiment_key,
-                            'status': 'ACTIVE',
-                            'type': 'optimizely',
-                            'variations': []}
-                    return OptimizelyFeatureTest(None, **data)
+        if self.is_optimizey_configured():
+            config = optimizely_sdk.get_optimizely_config()
+            if config:
+                if feature in config.features_map:
+                    optimizely_feature = config.features_map[feature]
+                    experiment_keys = optimizely_feature.experiments_map.keys()
+                    if len(experiment_keys) > 0:
+                        experiment_key = list(experiment_keys)[0]
+                        experiment = optimizely_feature.experiments_map[experiment_key]
+                        data = {'id': experiment.id,
+                                'feature': feature,
+                                'name': experiment_key,
+                                'status': 'ACTIVE',
+                                'type': 'optimizely',
+                                'variations': []}
+                        return OptimizelyFeatureTest(None, **data)
 
         table = self.__get_table()
         

--- a/src/recommendations/src/recommendations-service/experimentation/experiment_optimizely.py
+++ b/src/recommendations/src/recommendations-service/experimentation/experiment_optimizely.py
@@ -7,7 +7,7 @@ from optimizely import optimizely
 
 from . import experiment, resolvers
 
-
+optimizely_configured = os.environ.get('OPTIMIZELY_SDK_KEY', 'NONE') != 'NONE'
 optimizely_sdk = optimizely.Optimizely(sdk_key=os.environ.get('OPTIMIZELY_SDK_KEY'))
 
 class OptimizelyFeatureTest(experiment.Experiment):


### PR DESCRIPTION
*Description of changes:*

There has been a recent significant jump in latency to some of the resources in the Recommendations service. This seems to be tied to the Optimizely integration when Optimizely is not configured. Since all of the recommendations calls check for an active experiment for the feature and Optimizely is part of the logic path, something in the Optimizely library must be doing some slow-running checking when it's in this non-configured state. Added logic to only check for an Optimizely experiment when Optimizely is configured in the Retail Demo Store deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
