### PR TITLE
Add feature to product image link query string

### DIFF
--- a/src/web-ui/src/public/components/Product.vue
+++ b/src/web-ui/src/public/components/Product.vue
@@ -2,7 +2,7 @@
   <div class="col-sm-12 col-md-4 col-lg-4 mb-4">
     <!-- Card -->
     <div class="card mx-auto h-100 product-card">
-      <router-link :to="{name:'ProductDetail', params: {id: product.id}, query: {exp: experimentCorrelationId}}">
+      <router-link :to="{name:'ProductDetail', params: {id: product.id}, query: {feature: feature, exp: experimentCorrelationId}}">
         <img :src="productImageURL" class="card-img-top" :alt="product.name">
       </router-link>
       <div class="card-body">


### PR DESCRIPTION
*Description of changes:*

Fix to minor issue of the `feature` name not being included in the query string for the link around the product image (like it is for the "Details" button just below it).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
