### PR TITLE
Remove copier dependency

### DIFF
--- a/src/products/Dockerfile
+++ b/src/products/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.11-alpine AS build
+FROM golang:1.15-alpine AS build
 WORKDIR /src/
 RUN apk add --no-cache git bash
 RUN go get -u github.com/gorilla/mux
 RUN go get -u gopkg.in/yaml.v2
 RUN go get -u github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute
-RUN go get -u github.com/jinzhu/copier
 RUN go get -u github.com/google/uuid
 COPY src/products-service/*.* /src/
 COPY src/products-service/data/*.* /src/data/

--- a/src/products/src/products-service/product.go
+++ b/src/products/src/products-service/product.go
@@ -7,8 +7,8 @@ package main
 // using omitempty as a DynamoDB optimization to create indexes
 // IMPORTANT: if you change the shape of this struct, be sure to update the retaildemostore-lambda-load-products Lambda too!
 type Product struct {
-	ID             string  `json:"id" yaml:"id" copier:"-"`
-	URL            string  `json:"url" yaml:"url" copier:"-"`
+	ID             string  `json:"id" yaml:"id"`
+	URL            string  `json:"url" yaml:"url"`
 	SK             string  `json:"sk" yaml:"sk"`
 	Name           string  `json:"name" yaml:"name"`
 	Category       string  `json:"category" yaml:"category"`

--- a/src/products/src/products-service/repository.go
+++ b/src/products/src/products-service/repository.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	guuuid "github.com/google/uuid"
-	"github.com/jinzhu/copier"
 )
 
 // Root/base URL to use when building fully-qualified URLs to product detail view.
@@ -387,9 +386,6 @@ func RepoUpdateProduct(existingProduct *Product, updatedProduct *Product) error 
 	updatedProduct.ID = existingProduct.ID // Ensure we're not changing product ID.
 	updatedProduct.URL = ""                // URL is generated so ignore if specified
 	log.Printf("UpdateProduct from %#v to %#v", existingProduct, updatedProduct)
-
-	copier.Copy(existingProduct, updatedProduct)
-	log.Printf("after Copier %#v", updatedProduct)
 
 	av, err := dynamodbattribute.MarshalMap(updatedProduct)
 


### PR DESCRIPTION
*Description of changes:*

Bug introduced in the "copier" library dependency was causing compile errors. Removed as dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
