### PR TITLE
Fix recommendations section with missing heading

### DIFF
--- a/src/web-ui/src/public/Main.vue
+++ b/src/web-ui/src/public/Main.vue
@@ -91,13 +91,13 @@ export default {
           } else if (experimentName) {
             this.userRecommendationsTitle = 'Recommended for you';
           }
+
+          this.userRecommendations = response.data;
+
+          if (this.userRecommendations.length > 0 && 'experiment' in this.userRecommendations[0]) {
+            AnalyticsHandler.identifyExperiment(this.user, this.userRecommendations[0].experiment);
+          }
         }
-      }
-
-      this.userRecommendations = response.data;
-
-      if (this.userRecommendations.length > 0 && 'experiment' in this.userRecommendations[0]) {
-        AnalyticsHandler.identifyExperiment(this.user, this.userRecommendations[0].experiment);
       }
     },
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ensures that either `x-personalize-recipe `or `x-experiment-name` headers are present in order to display user recommendations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
