### PR TITLE
Use flag to determine if recommendations are loading

### DIFF
--- a/src/web-ui/src/public/Main.vue
+++ b/src/web-ui/src/public/Main.vue
@@ -2,7 +2,10 @@
   <Layout>
     <div class="content container">
       <RecommendedProductsSection
-        v-if="personalizeUserID"
+        v-if="
+          personalizeUserID &&
+            ((isLoadingRecommendations && !userRecommendations) || (!isLoadingRecommendations && userRecommendations))
+        "
         :feature="feature"
         :recommendedProducts="userRecommendations"
         :explainRecommended="explainRecommended"
@@ -44,6 +47,7 @@ export default {
   data() {
     return {
       feature: EXPERIMENT_FEATURE,
+      isLoadingRecommendations: true,
       featuredProducts: null,
       userRecommendationsTitle: null,
       userRecommendations: null,
@@ -99,6 +103,8 @@ export default {
           }
         }
       }
+
+      this.isLoadingRecommendations = false;
     },
   },
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `RecommendedProductsSection` component renders a loading indicator if the `recommendedProducts` prop is `null`. Since `userRecommendations` remains `null` when we decide not to show recommendations after making fetching recommendations, the loader stays. This PR adds loading state for that section in order to bail out of showing it if the request has completed and we decided not to show recommendations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
