### PR TITLE
Clamp add to cart dropdown value

### DIFF
--- a/src/web-ui/src/public/ProductDetail.vue
+++ b/src/web-ui/src/public/ProductDetail.vue
@@ -32,7 +32,7 @@
               </button>
               <div class="dropdown-menu" aria-labelledby="quantity-dropdown">
                 <button
-                  v-for="i in Math.min(9, product.current_stock - quantityInCart)"
+                  v-for="i in Math.max(0, Math.min(9, product.current_stock - quantityInCart))"
                   :key="i"
                   class="dropdown-item"
                   @click="quantity = i"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Product detail page currently breaks if you add the maximum stock of a product, navigate to the cart page, add even more, and then navigate back to that product page. This PR resolves the thrown error by clamping a calculation so it's always >= 0 when cart quantity is greater than available stock.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
