### PR TITLE
added maxResults=100 parameter to list-schemas code

### DIFF
--- a/workshop/1-Personalization/1.1-Personalize.ipynb
+++ b/workshop/1-Personalization/1.1-Personalize.ipynb
@@ -642,10 +642,11 @@
     "    print(json.dumps(create_schema_response, indent=2))\n",
     "except personalize.exceptions.ResourceAlreadyExistsException:\n",
     "    print('You aready created this schema, seemingly')\n",
-    "    schemas = personalize.list_schemas()['schemas']\n",
+    "    schemas = personalize.list_schemas(maxResults=100)['schemas']\n",
     "    for schema_response in schemas:\n",
     "        if schema_response['name'] == \"retaildemostore-schema-items\":\n",
     "            items_schema_arn = schema_response['schemaArn']\n",
+    "            print(f\"Using existing schema: {items_schema_arn}\")\n",
     "    \n"
    ]
   },
@@ -693,10 +694,11 @@
     "    users_schema_arn = create_schema_response['schemaArn']\n",
     "except personalize.exceptions.ResourceAlreadyExistsException:\n",
     "    print('You aready created this schema, seemingly')\n",
-    "    schemas = personalize.list_schemas()['schemas']\n",
+    "    schemas = personalize.list_schemas(maxResults=100)['schemas']\n",
     "    for schema_response in schemas:\n",
     "        if schema_response['name'] == \"retaildemostore-schema-users\":\n",
     "            users_schema_arn = schema_response['schemaArn']\n",
+    "            print(f\"Using existing schema: {users_schema_arn}\")\n",
     "    \n",
     "\n"
    ]
@@ -752,10 +754,11 @@
     "    interactions_schema_arn = create_schema_response['schemaArn']\n",
     "except personalize.exceptions.ResourceAlreadyExistsException:\n",
     "    print('You aready created this schema, seemingly')\n",
-    "    schemas = personalize.list_schemas()['schemas']\n",
+    "    schemas = personalize.list_schemas(maxResults=100)['schemas']\n",
     "    for schema_response in schemas:\n",
     "        if schema_response['name'] == \"retaildemostore-schema-interactions\":\n",
-    "            interactions_schema_arn = schema_response['schemaArn']"
+    "            interactions_schema_arn = schema_response['schemaArn']\n",
+    "            print(f\"Using existing schema: {interactions_schema_arn}\")"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

The recovery code that checks for existing schemas did not take into account that there may be more than the default number of results from the list-schemas API call, this broke the Personalize notebook for me.

*Description of changes:*

Added a maxResults=100 parameter to the list-schemas call and a print statement to notify workshop participants that an existing schema is being used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
