### PR TITLE
Add product to purchase back to notebook

### DIFF
--- a/workshop/1-Personalization/1.1-Personalize.ipynb
+++ b/workshop/1-Personalization/1.1-Personalize.ipynb
@@ -2496,6 +2496,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "product_id_to_purchase = random.choice(item_list)['itemId']\n",
+    "print(f'Product to simulate purchasing: {product_id_to_purchase}')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
*Description of changes:*

For some reason the cell to randomly select a product to purchase was recently removed. This caused an error in the notebook. Added the cell back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
