### PR TITLE
Style tweaks

### DIFF
--- a/src/web-ui/src/components/Carousel/Carousel.vue
+++ b/src/web-ui/src/components/Carousel/Carousel.vue
@@ -29,7 +29,7 @@ export default {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  border: 1px solid var(--grey-500);
+  border: 1px solid var(--grey-300);
   cursor: pointer;
   background: var(--white);
   padding: 10px 5px;

--- a/src/web-ui/src/components/DemoGuideBadge/DemoGuideBadge.vue
+++ b/src/web-ui/src/components/DemoGuideBadge/DemoGuideBadge.vue
@@ -58,7 +58,7 @@ export default {
         case Articles.SMS_MESSAGING:
           return 'Learn more about personalized product recommendations via SMS';
         case Articles.USER_PERSONALIZATION:
-          return 'Learn more about sser personalization';
+          return 'Learn more about user personalization';
         case Articles.PERSONALIZED_RANKING:
           return 'Learn more about personalized rankings';
         case Articles.SIMILAR_ITEM_RECOMMENDATIONS:

--- a/src/web-ui/src/components/Layout/Layout.vue
+++ b/src/web-ui/src/components/Layout/Layout.vue
@@ -111,6 +111,12 @@ export default {
   width: 90%;
   max-width: 400px;
 }
+
+@media (min-width: 992px) {
+  .layout--has-nav {
+    padding-top: 150px;
+  }
+}
 </style>
 
 <style>

--- a/src/web-ui/src/components/RecommendedProductsSection/ProductCarousel/ProductCarousel.vue
+++ b/src/web-ui/src/components/RecommendedProductsSection/ProductCarousel/ProductCarousel.vue
@@ -99,7 +99,7 @@ export default {
 
 <style scoped>
 .featured-product {
-  border: 1px solid var(--grey-500);
+  border: 1px solid var(--grey-300);
   text-decoration: none;
   color: inherit;
 }

--- a/src/web-ui/src/components/RecommendedProductsSection/ProductCarousel/ProductCarousel.vue
+++ b/src/web-ui/src/components/RecommendedProductsSection/ProductCarousel/ProductCarousel.vue
@@ -11,19 +11,23 @@
           params: { id: recommendation.product.id },
           query: { exp: getExperimentCorrelationId(recommendation.experiment), feature },
         }"
-        class="featured-product p-3 d-flex flex-column justify-content-between"
+        class="featured-product d-flex flex-column justify-content-between"
       >
         <div>
-          <img :src="getProductImageUrl(recommendation.product)" alt="" class="mb-2 img-fluid" />
-          <div class="product-name">
-            {{ recommendation.product.name }}
-          </div>
+          <div class="mb-2"><img :src="getProductImageUrl(recommendation.product)" alt="" class="img-fluid" /></div>
 
-          <FiveStars class="my-1"></FiveStars>
-          <div>{{ formatPrice(recommendation.product.price) }}</div>
+          <div class="px-3 pb-3">
+            <div class="product-name">
+              {{ recommendation.product.name }}
+            </div>
+
+            <FiveStars class="my-1"></FiveStars>
+            <div>{{ formatPrice(recommendation.product.price) }}</div>
+          </div>
         </div>
-        <div v-if="recommendation.experiment" class="experiment mt-1 d-flex align-items-center text-muted">
-          <i class="fa fa-balance-scale mr-2"></i> {{ getExperimentDescription(recommendation.experiment) }}
+
+        <div v-if="recommendation.experiment" class="experiment mt-1 p-3 d-flex align-items-center text-muted">
+          <i class="icon-scale fa fa-balance-scale mr-2"></i> {{ getExperimentDescription(recommendation.experiment) }}
         </div>
       </router-link>
     </div>
@@ -106,12 +110,16 @@ export default {
 
 .product-name {
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
 .experiment {
   font-size: 0.95rem;
+}
+
+.scale-icon { 
+  color: var(--blue-600);
 }
 </style>

--- a/src/web-ui/src/partials/Navigation/NavSeparator/NavSeparator.vue
+++ b/src/web-ui/src/partials/Navigation/NavSeparator/NavSeparator.vue
@@ -12,6 +12,6 @@ export default {
 .separator {
   width: 1px;
   height: 50px;
-  background: var(--grey-500);
+  background: var(--grey-300);
 }
 </style>

--- a/src/web-ui/src/partials/Navigation/Search/Search.vue
+++ b/src/web-ui/src/partials/Navigation/Search/Search.vue
@@ -135,7 +135,7 @@ export default {
 .input {
   width: 175px;
   border-style: solid;
-  border-width: 2px;
+  border-width: 1px;
   border-color: var(--grey-500);
   border-radius: 4px;
   padding-left: 40px;

--- a/src/web-ui/src/partials/Navigation/Search/Search.vue
+++ b/src/web-ui/src/partials/Navigation/Search/Search.vue
@@ -126,6 +126,7 @@ export default {
   transform: translateY(-50%);
   color: var(--grey-500);
   transition: color 150ms ease-in-out;
+  pointer-events: none;
 }
 
 .fa-search--focused {

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -12,7 +12,7 @@
 
           <div class="col-sm-3 col-md-3 col-lg-3 text-left">
             <h4 class="bg-light p-2">Filters</h4>
-            <div class="border-bottom">
+            <div class="gender-filter-border">
               <a
                 class="filter-title mb-1 mt-1"
                 data-toggle="collapse"
@@ -225,5 +225,9 @@ export default {
   }
   [aria-expanded='true'] > .chevron {
     transform: rotate(0deg);
+  }
+
+  .gender-filter-border {
+    border-bottom: 1px solid var(--grey-300);
   }
 </style>

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -8,9 +8,9 @@
         <div v-if="explain_recommended" class="text-muted text-left">
           <small><em><i v-if="active_experiment" class="fa fa-balance-scale"></i><i v-if="personalized" class="fa fa-user-check"></i> {{ explain_recommended }}</em></small>
         </div>
-        <div class="row mt-4">
 
-          <div class="col-sm-3 col-md-3 col-lg-3 text-left">
+        <div class="mt-4 d-flex flex-column flex-lg-row">
+          <div class="filters mb-4 mb-lg-4 mr-lg-4 text-left">
             <h4 class="bg-light p-2">Filters</h4>
             <div class="gender-filter-border">
               <a
@@ -55,7 +55,7 @@
             </div>
           </div>
 
-          <div class="card-deck col-sm-9 col-md-9 col-lg-9">
+          <div class="products">
             <Product v-for="product in filteredProducts"
               v-bind:key="product.id"
               :product="product"
@@ -197,16 +197,9 @@ export default {
     padding-top: 1rem;
   }
 
-  .carousel {
-    max-height: 600px;
-  }
-
-  .carousel-item {
-    max-height: 600px;
-  }
-
-  .card-deck {
-    align-self: flex-start;
+  .products {
+    flex: 1;
+    align-self: center;
     display: grid;
     grid-gap: 1rem;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr) ) ;
@@ -230,5 +223,15 @@ export default {
 
   .gender-filter-border {
     border-bottom: 1px solid var(--grey-300);
+  }
+
+  @media(min-width: 992px) {
+    .filters {
+      width: 300px;
+    } 
+
+    .products {
+      align-self: flex-start;
+    }
   }
 </style>

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -17,13 +17,13 @@
                 class="filter-title mb-1 mt-1"
                 data-toggle="collapse"
                 data-target="#gender-filter"
-                aria-expanded="true"
+                :aria-expanded="!isInitiallyMobile"
                 aria-controls="gender-filter"
               >
                 <i class="chevron fa fa-chevron-up ml-2"></i>
                 Gender
               </a>
-              <div class="collapse show" id="gender-filter" ref="genderCollapse">
+              <div :class="['collapse', isInitiallyMobile ? 'hide' : 'show']" id="gender-filter" ref="genderCollapse">
                 <div class="p-1 pl-2" v-for="gender in [ 'M', 'F' ]" v-bind:key="gender">
                   <label class="mb-1">
                     <input class="mr-1" type="checkbox" :value="gender" v-model="selectedGenders">
@@ -38,13 +38,13 @@
                 class="filter-title mb-1 mt-1"
                 data-toggle="collapse"
                 data-target="#style-filter"
-                aria-expanded="true"
+                :aria-expanded="!isInitiallyMobile"
                 aria-controls="style-filter"
               >
                 <i class="chevron fa fa-chevron-up ml-2"></i>
                 Styles
               </a>
-              <div class="collapse show" id="style-filter" ref="styleCollapse">
+              <div :class="['collapse', isInitiallyMobile ? 'hide' : 'show']" id="style-filter" ref="styleCollapse">
                 <div class="p-1 pl-2" v-for="style in styles" v-bind:key="style">
                   <label class="mb-0">
                     <input class="mr-1" type="checkbox"  :value="style" v-model="selectedStyles">
@@ -101,7 +101,8 @@ export default {
       active_experiment: false,
       personalized: false,
       selectedGenders: [],
-      selectedStyles: []
+      selectedStyles: [],
+      isInitiallyMobile: window.matchMedia('(max-width: 992px)').matches
     }
   },
   created () {
@@ -110,10 +111,8 @@ export default {
   mounted() {
     this.mediaQueryList = window.matchMedia('(max-width: 992px)');
 
-    this.listener = () => {
-      // eslint-disable-next-line no-undef
-      $([this.$refs.genderCollapse, this.$refs.styleCollapse]).collapse(this.mediaQueryList.matches ? 'hide' : 'show');
-    };
+    // eslint-disable-next-line no-undef
+    this.listener = () => $([this.$refs.genderCollapse, this.$refs.styleCollapse]).collapse(this.mediaQueryList.matches ? 'hide' : 'show');
 
     this.mediaQueryList.addEventListener('change', this.listener);
   },

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <Layout :loading="!products.length">
+  <Layout :isLoading="!products.length">
     <div class="content">
 
       <!-- Product List -->
@@ -206,6 +206,7 @@ export default {
   }
 
   .card-deck {
+    align-self: flex-start;
     display: grid;
     grid-gap: 1rem;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr) ) ;

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -23,7 +23,7 @@
                 <i class="chevron fa fa-chevron-up ml-2"></i>
                 Gender
               </a>
-              <div class="collapse show" id="gender-filter">
+              <div class="collapse show" id="gender-filter" ref="genderCollapse">
                 <div class="p-1 pl-2" v-for="gender in [ 'M', 'F' ]" v-bind:key="gender">
                   <label class="mb-1">
                     <input class="mr-1" type="checkbox" :value="gender" v-model="selectedGenders">
@@ -44,7 +44,7 @@
                 <i class="chevron fa fa-chevron-up ml-2"></i>
                 Styles
               </a>
-              <div class="collapse show" id="style-filter">
+              <div class="collapse show" id="style-filter" ref="styleCollapse">
                 <div class="p-1 pl-2" v-for="style in styles" v-bind:key="style">
                   <label class="mb-0">
                     <input class="mr-1" type="checkbox"  :value="style" v-model="selectedStyles">
@@ -104,8 +104,21 @@ export default {
       selectedStyles: []
     }
   },
-  async created () {
+  created () {
     this.fetchData()
+  },
+  mounted() {
+    this.mediaQueryList = window.matchMedia('(max-width: 992px)');
+
+    this.listener = () => {
+      // eslint-disable-next-line no-undef
+      $([this.$refs.genderCollapse, this.$refs.styleCollapse]).collapse(this.mediaQueryList.matches ? 'hide' : 'show');
+    };
+
+    this.mediaQueryList.addEventListener('change', this.listener);
+  },
+  beforeDestroy() {
+    this.mediaQueryList.removeEventListener('change', this.listener);
   },
   methods: {
     async fetchData (){

--- a/src/web-ui/src/public/Checkout.vue
+++ b/src/web-ui/src/public/Checkout.vue
@@ -24,7 +24,7 @@
       <div class="container" v-if="cart">
         <div class="row text-left" v-if="showCheckout == true">
           <div class="col-md-auto order-md-2 summary-column">
-            <div class="card p-1">
+            <div class="summary-border-container card p-1">
               <div class="card-body">
                 <h4 class="d-flex justify-content-between align-items-center mb-3 card-title text-muted">
                   Order Summary
@@ -234,5 +234,9 @@ export default {
 
   .summary-column {
     min-width: 20em;
+  }
+
+  .summary-border-container {
+    border-color: var(--grey-300);
   }
 </style>

--- a/src/web-ui/src/public/Live.vue
+++ b/src/web-ui/src/public/Live.vue
@@ -103,9 +103,9 @@
           :explainRecommended="explainRecommended"
           :recommendedProducts="productRecommended"
           :feature="feature"
-          class="mt-4"
+          class="mt-5"
       >
-        <template #heading>Compare similar items</template>
+        <template #heading>Compare similar items <DemoGuideBadge :article="demoGuideBadgeArticle" hideTextOnSmallScreens></DemoGuideBadge></template>
       </RecommendedProductsSection>
 
     </div>
@@ -121,6 +121,8 @@ import RecommendedProductsSection from "@/components/RecommendedProductsSection/
 import {AnalyticsHandler} from "@/analytics/AnalyticsHandler";
 import {formatPrice} from "@/util/formatPrice";
 import {discountProductPrice} from "@/util/discountProductPrice";
+import { Articles } from '@/partials/AppModal/DemoGuide/config';
+import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
 
 const ProductsRepository = RepositoryFactory.get('products');
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
@@ -137,9 +139,11 @@ export default {
   components: {
     Layout,
     RecommendedProductsSection,
+    DemoGuideBadge,
   },
   data() {
     return {
+      demoGuideBadgeArticle: Articles.SIMILAR_ITEM_RECOMMENDATIONS,
       streamDetails: [],
       activeStreamId: 0,
       productDetails: [],

--- a/src/web-ui/src/public/components/Product.vue
+++ b/src/web-ui/src/public/components/Product.vue
@@ -90,7 +90,7 @@ export default {
   }
 
 .featured-product {
-  border: 1px solid var(--grey-500);
+  border: 1px solid var(--grey-300);
   text-decoration: none;
   color: inherit;
 }

--- a/src/web-ui/src/public/components/Product.vue
+++ b/src/web-ui/src/public/components/Product.vue
@@ -1,15 +1,19 @@
 <template>
-  <div class="featured-product p-3 d-flex flex-column justify-content-between text-left">
+  <div class="featured-product d-flex flex-column justify-content-between text-left">
     <!-- Card -->
     <router-link class="link" :to="{name:'ProductDetail', params: {id: product.id}, query: {feature: feature, exp: experimentCorrelationId}}">
       <div>
-        <img :src="productImageURL" class="card-img-top" :alt="product.name">
-        <div class="product-name">{{ product.name }}</div>
-        <FiveStars />
-        <div>${{ product.price.toFixed(2) }}</div>
+        <div class="p3"><img :src="productImageURL" class="card-img-top" :alt="product.name"></div>
+
+        <div class="p-3">
+          <div class="product-name">{{ product.name }}</div>
+          <FiveStars />
+          <div>${{ product.price.toFixed(2) }}</div>
+        </div>
       </div>
-      <div v-if="experiment" class="experiment mt-1 d-flex align-items-center text-muted">
-        <i class="fa fa-balance-scale mr-2"></i> {{ experimentDescription }}
+
+      <div v-if="experiment" class="experiment mt-1 p-3 d-flex align-items-center text-muted">
+        <i class="scale-icon fa fa-balance-scale mr-2"></i> {{ experimentDescription }}
       </div>
     </router-link>
   </div>
@@ -97,9 +101,12 @@ export default {
 
 .product-name {
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
+.scale-icon { 
+  color: var(--blue-600);
+}
 </style>

--- a/src/web-ui/src/styles/tokens.css
+++ b/src/web-ui/src/styles/tokens.css
@@ -10,6 +10,7 @@
   --blue-500: #00a1c9;
   --blue-600: #0073bb;
   --grey-200: #eaeded;
+  --grey-300: #d5dbdb;
   --grey-400: #aab7b8;
   --grey-500: #879596;
   --grey-600: #545b64;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes: 
- Fix typo on demo guide badge
- Introduce grey-300 color and use for borders where appropriate
- Adjust padding on `Layout`
- Reduce search bar border width and give icon `pointer-events: none` so that clicking it focuses the input element as well
- Add demo guide badge on "Compare similar items" section on `/live`
- Remove padding from images in product cards and make experiment icon blue
- Improve responsiveness of cards on category page
- Fix product cards stretching when there are not enough rows for the product cards section to be taller than filters
- Make category page filters hidden on mobile and shown on desktop by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
