### PR TITLE
Update auth screen to be own component and render conditional message

### DIFF
--- a/src/web-ui/src/App.vue
+++ b/src/web-ui/src/App.vue
@@ -14,7 +14,7 @@ export default {
   },
   created() {
     this.getCategories();
-    
+
     this.getCart();
   },
 };
@@ -29,65 +29,4 @@ body {
   font-family: Ember, sans-serif;
 }
 
-/* Amplify Auth Form Styling */
-
-/* On xs screens, override default min-width on forms to prevent overflow */
-@media (max-width: 576px) {
-  div[data-test="sign-in-section"],
-  div[data-test="sign-up-section"],
-  div[data-test="verify-contact-section"],
-  div[data-test="require-new-password-section"],
-  div[data-test="federated-sign-in-section"],
-  div[data-test="confirm-sign-up-section"],
-  div[data-test="confirm-sign-in-section"],
-  div[data-test="set-mfa-section"],
-  div[data-test="forgot-password-section"] {
-    min-width: initial !important;
-  }
-}
-
-/* Set font-size to 16px to disable auto-zoom on mobile Safari */
-div[data-test="sign-in-section"] input,
-div[data-test="sign-up-section"] input,
-div[data-test="verify-contact-section"] input,
-div[data-test="require-new-password-section"] input,
-div[data-test="federated-sign-in-section"] input,
-div[data-test="confirm-sign-up-section"] input,
-div[data-test="confirm-sign-in-section"] input,
-div[data-test="set-mfa-section"] input,
-div[data-test="forgot-password-section"] input {
-  font-size: 16px !important;
-}
-
-/* Make links in form text/labels more noticeable */
-div[data-test="sign-in-section"] a,
-div[data-test="sign-up-section"] a,
-div[data-test="verify-contact-section"] a,
-div[data-test="require-new-password-section"] a,
-div[data-test="federated-sign-in-section"] a,
-div[data-test="confirm-sign-up-section"] a,
-div[data-test="confirm-sign-in-section"] a,
-div[data-test="set-mfa-section"] a,
-div[data-test="forgot-password-section"] a {
-  color: #007bff !important;
-}
-
-/* Make error messages stand out and match bootstrap alert-error */
-div[data-test="sign-in-section"] div.error,
-div[data-test="sign-up-section"] div.error,
-div[data-test="verify-contact-section"] div.error,
-div[data-test="require-new-password-section"] div.error,
-div[data-test="federated-sign-in-section"] div.error,
-div[data-test="confirm-sign-up-section"] div.error,
-div[data-test="confirm-sign-in-section"] div.error,
-div[data-test="set-mfa-section"] div.error,
-div[data-test="forgot-password-section"] div.error {
-  color: #721c24;
-  background-color: #f8d7da;
-  position: relative;
-  padding: .75rem 1.25rem;
-  margin-top: 1rem;
-  border: 1px solid #f5c6cb;
-  border-radius: .25rem;
-}
 </style>

--- a/src/web-ui/src/public/Auth.vue
+++ b/src/web-ui/src/public/Auth.vue
@@ -1,0 +1,148 @@
+<template>
+  <secondary-layout>
+    <div v-if="showingSignUp" class="sign-up-notice">
+      <p>A verification code will be sent to the email address entered.</p>
+      <p>Passwords must contain at least 8 characters, including an uppercase latter, a lowercase latter, a special character, and a number.</p>
+    </div>
+    <AmplifyAuthenticator :authConfig="authConfig" ref="authenticator" />
+  </secondary-layout>
+</template>
+
+<script>
+import { components } from 'aws-amplify-vue';
+import SecondaryLayout from '../components/SecondaryLayout/SecondaryLayout.vue';
+
+
+export default {
+  name: 'Auth',
+  components: {
+    AmplifyAuthenticator: components.Authenticator,
+    SecondaryLayout
+  },
+  data() {
+    return {
+      showingSignUp: false,
+      authConfig: {
+        signInConfig: {
+          header: 'Sign In'
+        },
+        signUpConfig: {
+          hideAllDefaults: true,
+          header: 'Create account',
+          signUpFields: [
+            {
+              label: 'Email',
+              key: 'email',
+              type: 'email',
+              required: true
+            },
+            {
+              label: 'Password',
+              key: 'password',
+              type: 'password',
+              required: true
+            },
+            {
+              label: 'Username',
+              key: 'username',
+              type: 'string',
+              required: true
+            },
+          ]
+        }
+      }
+    }
+  },
+  mounted() {
+    this.$refs['authenticator'].$watch('displayMap', (newVal) => {
+      this.showingSignUp = newVal.showSignUp
+    })
+  }
+}
+</script>
+
+<style>
+
+.sign-up-notice {
+  display: inline-block;
+  max-width: 460px;
+  padding: 0 40px;
+  text-align: left;
+}
+
+
+/* Amplify Auth Form Styling */
+
+div[data-test="sign-in-section"],
+div[data-test="sign-up-section"],
+div[data-test="verify-contact-section"],
+div[data-test="require-new-password-section"],
+div[data-test="federated-sign-in-section"],
+div[data-test="confirm-sign-up-section"],
+div[data-test="confirm-sign-in-section"],
+div[data-test="set-mfa-section"],
+div[data-test="forgot-password-section"] {
+  box-shadow: none;
+}
+
+/* On xs screens, override default min-width on forms to prevent overflow */
+@media (max-width: 576px) {
+  div[data-test="sign-in-section"],
+  div[data-test="sign-up-section"],
+  div[data-test="verify-contact-section"],
+  div[data-test="require-new-password-section"],
+  div[data-test="federated-sign-in-section"],
+  div[data-test="confirm-sign-up-section"],
+  div[data-test="confirm-sign-in-section"],
+  div[data-test="set-mfa-section"],
+  div[data-test="forgot-password-section"] {
+    min-width: initial !important;
+  }
+}
+
+/* Set font-size to 16px to disable auto-zoom on mobile Safari */
+div[data-test="sign-in-section"] input,
+div[data-test="sign-up-section"] input,
+div[data-test="verify-contact-section"] input,
+div[data-test="require-new-password-section"] input,
+div[data-test="federated-sign-in-section"] input,
+div[data-test="confirm-sign-up-section"] input,
+div[data-test="confirm-sign-in-section"] input,
+div[data-test="set-mfa-section"] input,
+div[data-test="forgot-password-section"] input {
+  font-size: 16px !important;
+  padding: .5em;
+}
+
+/* Make links in form text/labels more noticeable */
+div[data-test="sign-in-section"] a,
+div[data-test="sign-up-section"] a,
+div[data-test="verify-contact-section"] a,
+div[data-test="require-new-password-section"] a,
+div[data-test="federated-sign-in-section"] a,
+div[data-test="confirm-sign-up-section"] a,
+div[data-test="confirm-sign-in-section"] a,
+div[data-test="set-mfa-section"] a,
+div[data-test="forgot-password-section"] a {
+  color: var(--blue-500) !important;
+}
+
+/* Make error messages stand out and match bootstrap alert-error */
+div[data-test="sign-in-section"] div.error,
+div[data-test="sign-up-section"] div.error,
+div[data-test="verify-contact-section"] div.error,
+div[data-test="require-new-password-section"] div.error,
+div[data-test="federated-sign-in-section"] div.error,
+div[data-test="confirm-sign-up-section"] div.error,
+div[data-test="confirm-sign-in-section"] div.error,
+div[data-test="set-mfa-section"] div.error,
+div[data-test="forgot-password-section"] div.error {
+  color: #721c24;
+  background-color: #f8d7da;
+  position: relative;
+  padding: .75rem 1.25rem;
+  margin-top: 1rem;
+  border: 1px solid #f5c6cb;
+  border-radius: .25rem;
+}
+</style>

--- a/src/web-ui/src/public/Auth.vue
+++ b/src/web-ui/src/public/Auth.vue
@@ -1,7 +1,7 @@
 <template>
   <SecondaryLayout>
     <div v-if="showingSignUp" class="sign-up-notice">
-      <p>A verification code will be sent to the email address entered.</p>
+      <p>We require you to enter an email address to send a code to verify your account.</p>
       <p>Passwords must contain at least 8 characters, including an uppercase letter, a lowercase letter, a special character, and a number.</p>
     </div>
     <AmplifyAuthenticator :authConfig="authConfig" ref="authenticator" />

--- a/src/web-ui/src/public/Auth.vue
+++ b/src/web-ui/src/public/Auth.vue
@@ -54,7 +54,7 @@ export default {
     }
   },
   mounted() {
-    this.$refs['authenticator'].$watch('displayMap', (newVal) => {
+    this.$refs.authenticator.$watch('displayMap', (newVal) => {
       // since the first displayMap update happens asynchronously on mount,
       // it may not have picked up the authState emit below. So in the
       // very first update, check and pull the value from query if set

--- a/src/web-ui/src/public/Auth.vue
+++ b/src/web-ui/src/public/Auth.vue
@@ -1,16 +1,16 @@
 <template>
-  <secondary-layout>
+  <SecondaryLayout>
     <div v-if="showingSignUp" class="sign-up-notice">
       <p>A verification code will be sent to the email address entered.</p>
       <p>Passwords must contain at least 8 characters, including an uppercase letter, a lowercase letter, a special character, and a number.</p>
     </div>
     <AmplifyAuthenticator :authConfig="authConfig" ref="authenticator" />
-  </secondary-layout>
+  </SecondaryLayout>
 </template>
 
 <script>
 import { components, AmplifyEventBus } from 'aws-amplify-vue';
-import SecondaryLayout from '../components/SecondaryLayout/SecondaryLayout.vue';
+import SecondaryLayout from '@/components/SecondaryLayout/SecondaryLayout';
 
 
 export default {

--- a/src/web-ui/src/public/Welcome.vue
+++ b/src/web-ui/src/public/Welcome.vue
@@ -26,7 +26,6 @@
         </ul>
       </div>
 
-      <!-- make both links to go /auth until we have dedicated sign in and create account pages -->
       <div class="mt-2 mb-4 my-sm-5 d-flex flex-column align-items-center align-items-sm-end">
         <div class="d-flex flex-column flex-sm-row align-items-center">
           <div class="login-cta d-flex justify-content-center align-items-center">

--- a/src/web-ui/src/public/Welcome.vue
+++ b/src/web-ui/src/public/Welcome.vue
@@ -32,7 +32,7 @@
           <div class="login-cta d-flex justify-content-center align-items-center">
             Have an account?<router-link to="/auth" class="sign-in btn btn-link">Sign in</router-link>
           </div>
-          <router-link to="/auth" class="create-account mt-3 mt-sm-0 ml-sm-3 btn btn-primary"
+          <router-link to="/auth?signup=true" class="create-account mt-3 mt-sm-0 ml-sm-3 btn btn-primary"
             >Create an account</router-link
           >
         </div>

--- a/src/web-ui/src/router/index.js
+++ b/src/web-ui/src/router/index.js
@@ -9,13 +9,14 @@ import CategoryDetail from '@/public/CategoryDetail.vue'
 import Live from '@/public/Live.vue'
 import Help from '@/public/Help.vue'
 import Cart from '@/public/Cart.vue'
+import AuthScreen from '@/public/Auth.vue'
 import Checkout from '@/public/Checkout.vue'
 import Welcome from '@/public/Welcome.vue'
 import Orders from '@/authenticated/Orders.vue'
 import Admin from '@/authenticated/Admin.vue'
 import ShopperSelectPage from '@/authenticated/ShopperSelectPage'
 
-import { components, AmplifyEventBus } from 'aws-amplify-vue';
+import { AmplifyEventBus } from 'aws-amplify-vue';
 import { Auth, Logger, I18n, Analytics, Interactions } from 'aws-amplify';
 import { AmplifyPlugin } from 'aws-amplify-vue';
 import AmplifyStore from '@/store/store';
@@ -238,35 +239,7 @@ const router = new Router({
     {
       path: '/auth',
       name: 'Authenticator',
-      component: components.Authenticator,
-      props: {
-        authConfig: {
-          signUpConfig: {
-            hideAllDefaults: true,
-            header: 'Create new account',
-            signUpFields: [
-              {
-                label: 'Email',
-                key: 'email',
-                type: 'email',
-                required: true
-              },
-              {
-                label: 'Password',
-                key: 'password',
-                type: 'password',
-                required: true
-              },
-              {
-                label: 'Username',
-                key: 'username',
-                type: 'string',
-                required: true
-              }
-            ]
-          }
-        }
-      }
+      component: AuthScreen,
     },
     {
       path: '/shopper-select',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Moves authenticator into own component now using SecndaryLayout
* Minor styling tweaks to remove box shadow and use consistent link color, but not introduce any further CSS hacking inside authenticator
* Watches the display state of the authenticator form and conditionally renders notice above the sign up form


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
