### PR TITLE
fix PUT /carts/id/{cartID} endpoint

### DIFF
--- a/src/carts/src/carts-service/cart.go
+++ b/src/carts/src/carts-service/cart.go
@@ -10,9 +10,6 @@ type Cart struct {
 	Items    CartItems `json:"items" yaml:"items"`
 }
 
-// Carts Array
-type Carts []Cart
-
 // CartItem Struct
 type CartItem struct {
 	ProductID string  `json:"product_id" yaml:"product_id"`

--- a/src/carts/src/carts-service/handlers.go
+++ b/src/carts/src/carts-service/handlers.go
@@ -6,12 +6,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path"
-
-	"github.com/gorilla/mux"
 )
 
 // Index Handler
@@ -72,9 +70,10 @@ func CartUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	id := path.Base(r.URL.Path)
+	vars := mux.Vars(r)
+	cartID := vars["cartID"]
 
-	t := RepoUpdateCart(id, cart)
+	t := RepoUpdateCart(cartID, cart)
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusCreated)

--- a/src/carts/src/carts-service/handlers.go
+++ b/src/carts/src/carts-service/handlers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"path"
 
 	"github.com/gorilla/mux"
 )
@@ -25,7 +26,12 @@ func CartIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 
-	if err := json.NewEncoder(w).Encode(carts); err != nil {
+	var values []Cart
+	for _, value := range carts {
+		values = append(values, value)
+	}
+
+	if err := json.NewEncoder(w).Encode(values); err != nil {
 		panic(err)
 	}
 }
@@ -66,7 +72,10 @@ func CartUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	t := RepoUpdateCart(cart)
+	id := path.Base(r.URL.Path)
+
+	t := RepoUpdateCart(id, cart)
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(t); err != nil {
@@ -99,6 +108,7 @@ func CartCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	t := RepoCreateCart(cart)
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(t); err != nil {

--- a/src/carts/src/carts-service/main.go
+++ b/src/carts/src/carts-service/main.go
@@ -6,9 +6,15 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 )
 
 func main() {
+	port, exists := os.LookupEnv("PORT")
+	if !exists {
+		port = "80"
+	}
+
 	router := NewRouter()
-	log.Fatal(http.ListenAndServe(":80", router))
+	log.Fatal(http.ListenAndServe(":" + port, router))
 }

--- a/src/carts/src/carts-service/repository.go
+++ b/src/carts/src/carts-service/repository.go
@@ -9,41 +9,37 @@ import (
 
 var currentID int
 
-var carts Carts = Carts{}
+var carts = map[string]Cart{}
 
-func init() {
-}
 
 // RepoFindCartByID Function
 func RepoFindCartByID(id string) Cart {
-	for _, t := range carts {
-		if t.ID == id {
-			return t
-		}
+	cart, ok := carts[id]
+	if !ok {
+		return Cart{}
 	}
-	// return empty Cart if not found
-	return Cart{}
+	return cart
 }
 
 // RepoUpdateCart Function
-func RepoUpdateCart(t Cart) Cart {
+func RepoUpdateCart(id string, cart Cart) Cart {
+	_, ok := carts[id]
 
-	for i := 0; i < len(carts); i++ {
-		c := &carts[i]
-		if c.ID == t.ID {
-			c.Items = t.Items
-			return RepoFindCartByID(t.ID)
-		}
+	if !ok {
+		// return empty Cart if not found
+		return Cart{}
 	}
 
-	// return empty Cart if not found
-	return Cart{}
+	cart.ID = id
+	carts[id] = cart
+
+	return cart
 }
 
 // RepoCreateCart Function
 func RepoCreateCart(t Cart) Cart {
 	currentID++
 	t.ID = strconv.Itoa(currentID)
-	carts = append(carts, t)
-	return RepoFindCartByID(t.ID)
+	carts[t.ID] = t
+	return t
 }


### PR DESCRIPTION
*Description of changes:*

This change fixes a bug that meant the `CartUpdate` function, called by the `/carts/id/{cartID}` route, did not update the cart as the id was not being passed to the function. I've also changed the implementation to use a hashmap rather than an array so we no longer have to iterate the data structure to find elements.

There are several other changes I think would be beneficial that I can add to this PR (or raise another one) regarding the REST API itself. I didn't make these changes because I didn't know if other services relied on these APIs (the frontend, for example):

- `GET /carts/all` is non-standard, it should be `GET /carts`
- `GET /carts/id/{cartID}` is non-standard, it should be `GET /carts/{id}`
- `PUT /carts/id/{cartID}` is non-standard, it should be `PUT /carts/{id}`
- `OPTIONS /carts/id/{cartID}` is non-standard, it should be `OPTIONS /carts/{id}`
-  When `GET /carts/id/{cartID}` is given an id that does not exist it returns and empty cart object, this should be a 404.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
