### PR TITLE
Conditional demo guide badges

### DIFF
--- a/src/web-ui/src/components/RecommendedProductsSection/RecommendedProductsSection.vue
+++ b/src/web-ui/src/components/RecommendedProductsSection/RecommendedProductsSection.vue
@@ -2,10 +2,9 @@
   <section>
     <div class="mb-3 text-left">
       <h2 class="recommendations-heading"><slot name="heading"></slot></h2>
-      <div v-if="explainRecommended" class="recommendation-explanation text-muted">
-        <i v-if="explainRecommended.activeExperiment" class="fa fa-balance-scale px-1"></i>
-        <i v-if="explainRecommended.personalized" class="fa fa-user-check px-1"></i>
-        {{ explainRecommended.explanation }}
+      <div v-if="experiment" class="recommendation-explanation text-muted">
+        <i class="fa fa-balance-scale px-1"></i>
+        {{ experiment }}
       </div>
     </div>
 
@@ -29,8 +28,8 @@ import ProductCarousel from './ProductCarousel/ProductCarousel';
 export default {
   name: 'RecommendedProductsSection',
   props: {
-    explainRecommended: {
-      type: Object,
+    experiment: {
+      type: String,
       required: false,
     },
     recommendedProducts: {

--- a/src/web-ui/src/partials/AppModal/DemoGuide/config.js
+++ b/src/web-ui/src/partials/AppModal/DemoGuide/config.js
@@ -79,3 +79,11 @@ sections.forEach((section) => {
 });
 
 export const getSectionIdFromArticleId = (articleId) => articleIdToSectionIdMap[articleId];
+
+const personalizeARNToDemoGuideArticleMap = {
+  'arn:aws:personalize:::recipe/aws-sims': Articles.SIMILAR_ITEM_RECOMMENDATIONS,
+  'arn:aws:personalize:::recipe/aws-personalized-ranking': Articles.PERSONALIZED_RANKING,
+  'arn:aws:personalize:::recipe/aws-user-personalization': Articles.USER_PERSONALIZATION,
+};
+
+export const getDemoGuideArticleFromPersonalizeARN = (arn) => personalizeARNToDemoGuideArticleMap[arn];

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -75,7 +75,7 @@ import { AnalyticsHandler } from '@/analytics/AnalyticsHandler'
 import Product from './components/Product.vue'
 import Layout from '@/components/Layout/Layout'
 import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
-import { Articles } from '@/partials/AppModal/DemoGuide/config';
+import { getDemoGuideArticleFromPersonalizeARN } from '@/partials/AppModal/DemoGuide/config';
 
 const ProductsRepository = RepositoryFactory.get('products')
 const RecommendationsRepository = RepositoryFactory.get('recommendations')
@@ -143,7 +143,7 @@ export default {
           const personalizeRecipe = response.headers['x-personalize-recipe'];
           const experimentName = response.headers['x-experiment-name'];
 
-          if (personalizeRecipe) this.demoGuideBadgeArticle = Articles.PERSONALIZED_RANKING;
+          if (personalizeRecipe) this.demoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe);
 
           if (experimentName) this.experiment = `Active experiment: ${experimentName}`
         }

--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -2,7 +2,7 @@
   <Layout :isLoading="!products.length">
       <!-- Product List -->
       <div class="container" v-if="products.length">
-        <h2 class="text-left">{{ this.display | capitalize }}</h2>
+        <h2 class="text-left">{{ this.display | capitalize }} <DemoGuideBadge :article="demoGuideBadgeArticle" hideTextOnSmallScreens></DemoGuideBadge></h2>
         <div v-if="explain_recommended" class="text-muted text-left">
           <small><em><i v-if="active_experiment" class="fa fa-balance-scale"></i><i v-if="personalized" class="fa fa-user-check"></i> {{ explain_recommended }}</em></small>
         </div>
@@ -74,6 +74,8 @@ import { AnalyticsHandler } from '@/analytics/AnalyticsHandler'
 
 import Product from './components/Product.vue'
 import Layout from '@/components/Layout/Layout'
+import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
+import { Articles } from '@/partials/AppModal/DemoGuide/config';
 
 const ProductsRepository = RepositoryFactory.get('products')
 const RecommendationsRepository = RepositoryFactory.get('recommendations')
@@ -86,10 +88,12 @@ export default {
   components: {
     Product,
     Layout,
+    DemoGuideBadge
   },
   data() {
     return {
       feature: ExperimentFeature,
+      demoGuideBadgeArticle: Articles.PERSONALIZED_RANKING,
       products: [],
       errors: [],
       display: '',

--- a/src/web-ui/src/public/Live.vue
+++ b/src/web-ui/src/public/Live.vue
@@ -121,8 +121,9 @@ import RecommendedProductsSection from "@/components/RecommendedProductsSection/
 import {AnalyticsHandler} from "@/analytics/AnalyticsHandler";
 import {formatPrice} from "@/util/formatPrice";
 import {discountProductPrice} from "@/util/discountProductPrice";
-import { Articles } from '@/partials/AppModal/DemoGuide/config';
 import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
+
+import {getDemoGuideArticleFromPersonalizeARN} from '@/partials/AppModal/DemoGuide/config'
 
 const ProductsRepository = RepositoryFactory.get('products');
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
@@ -195,7 +196,7 @@ export default {
 
         if (experimentName) this.experiment = `Active experiment: ${experimentName}`
 
-        if (personalizeRecipe) this.demoGuideBadgeArticle = Articles.SIMILAR_ITEM_RECOMMENDATIONS
+        if (personalizeRecipe) this.demoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe)
       }
 
       this.productRecommended = response.data;

--- a/src/web-ui/src/public/Live.vue
+++ b/src/web-ui/src/public/Live.vue
@@ -100,12 +100,12 @@
 
       <RecommendedProductsSection
           :key="`rec-products-${(new Date()).getTime()}`"
-          :explainRecommended="explainRecommended"
+          :experiment="experiment"
           :recommendedProducts="productRecommended"
           :feature="feature"
           class="mt-5"
       >
-        <template #heading>Compare similar items <DemoGuideBadge :article="demoGuideBadgeArticle" hideTextOnSmallScreens></DemoGuideBadge></template>
+        <template #heading>Compare similar items <DemoGuideBadge v-if="demoGuideBadgeArticle" :article="demoGuideBadgeArticle" hideTextOnSmallScreens></DemoGuideBadge></template>
       </RecommendedProductsSection>
 
     </div>
@@ -143,13 +143,13 @@ export default {
   },
   data() {
     return {
-      demoGuideBadgeArticle: Articles.SIMILAR_ITEM_RECOMMENDATIONS,
       streamDetails: [],
       activeStreamId: 0,
       productDetails: [],
       activeProductId: 0,
       productRecommended: null,
-      explainRecommended: null,
+      experiment: null,
+      demoGuideBadgeArticle: null,
       productActiveExperiment: false,
       feature: PRODUCT_EXPERIMENT_FEATURE,
       metadata: [],
@@ -178,8 +178,9 @@ export default {
       return data;
     },
     async getRelatedProducts() {
-      this.explainRecommended = null;
+      this.experiemnt = null
       this.productRecommended = null;
+      this.demoGuideBadgeArticle = null;
 
       const response = await RecommendationsRepository.getRelatedProducts(
           this.personalizeUserID ?? '',
@@ -192,17 +193,9 @@ export default {
         const experimentName = response.headers['x-experiment-name'];
         const personalizeRecipe = response.headers['x-personalize-recipe'];
 
-        if (experimentName || personalizeRecipe) {
-          const explanation = experimentName
-              ? `Active experiment: ${experimentName}`
-              : `Personalize recipe: ${personalizeRecipe}`;
+        if (experimentName) this.experiment = `Active experiment: ${experimentName}`
 
-          this.explainRecommended = {
-            activeExperiment: !!experimentName,
-            personalized: !!personalizeRecipe,
-            explanation,
-          };
-        }
+        if (personalizeRecipe) this.demoGuideBadgeArticle = Articles.SIMILAR_ITEM_RECOMMENDATIONS
       }
 
       this.productRecommended = response.data;

--- a/src/web-ui/src/public/Live.vue
+++ b/src/web-ui/src/public/Live.vue
@@ -179,7 +179,7 @@ export default {
       return data;
     },
     async getRelatedProducts() {
-      this.experiemnt = null
+      this.experiment = null
       this.productRecommended = null;
       this.demoGuideBadgeArticle = null;
 

--- a/src/web-ui/src/public/Main.vue
+++ b/src/web-ui/src/public/Main.vue
@@ -45,7 +45,7 @@ import Layout from '@/components/Layout/Layout';
 import RecommendedProductsSection from '@/components/RecommendedProductsSection/RecommendedProductsSection';
 import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
 
-import { Articles } from '@/partials/AppModal/DemoGuide/config';
+import { getDemoGuideArticleFromPersonalizeARN } from '@/partials/AppModal/DemoGuide/config';
 
 const ProductsRepository = RepositoryFactory.get('products');
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
@@ -96,7 +96,10 @@ export default {
 
       const { data, headers } = await ProductsRepository.getFeatured();
 
-      if (headers['x-personalize-recipe']) this.featuredProductsDemoGuideBadgeArticle = Articles.PERSONALIZED_RANKING;
+      const personalizeRecipe = headers['x-personalize-recipe'];
+
+      if (personalizeRecipe)
+        this.featuredProductsDemoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe);
 
       this.featuredProducts = data.slice(0, MAX_RECOMMENDATIONS).map((product) => ({ product }));
     },
@@ -126,7 +129,7 @@ export default {
               ? 'Inspired by your shopping trends'
               : 'Trending products';
 
-            this.userRecommendationsDemoGuideBadgeArticle = Articles.USER_PERSONALIZATION;
+            this.userRecommendationsDemoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe);
           } else if (experimentName) {
             this.userRecommendationsTitle = 'Recommended for you';
           }

--- a/src/web-ui/src/public/ProductDetail.vue
+++ b/src/web-ui/src/public/ProductDetail.vue
@@ -53,14 +53,14 @@
           </div>
         </main>
 
-        <RecommendedProductsSection
-          :explainRecommended="explainRecommended"
-          :recommendedProducts="relatedProducts"
-          :feature="feature"
-        >
+        <RecommendedProductsSection :experiment="experiment" :recommendedProducts="relatedProducts" :feature="feature">
           <template #heading
             >Compare similar items
-            <DemoGuideBadge :article="demoGuideBadgeArticle" hideTextOnSmallScreens></DemoGuideBadge>
+            <DemoGuideBadge
+              v-if="demoGuideBadgeArticle"
+              :article="demoGuideBadgeArticle"
+              hideTextOnSmallScreens
+            ></DemoGuideBadge>
           </template>
         </RecommendedProductsSection>
       </div>
@@ -112,8 +112,8 @@ export default {
       quantity: 1,
       feature: EXPERIMENT_FEATURE,
       relatedProducts: null,
-      explainRecommended: null,
-      demoGuideBadgeArticle: Articles.SIMILAR_ITEM_RECOMMENDATIONS,
+      demoGuideBadgeArticle: null,
+      experiment: null,
     };
   },
   computed: {
@@ -185,6 +185,9 @@ export default {
     async getRelatedProducts() {
       // reset in order to trigger recalculation in carousel - carousel UI breaks without this
       this.relatedProducts = null;
+      
+      this.experiment = null;
+      this.demoGuideBadgeArticle = null;
 
       const response = await RecommendationsRepository.getRelatedProducts(
         this.personalizeUserID ?? '',
@@ -197,17 +200,8 @@ export default {
         const experimentName = response.headers['x-experiment-name'];
         const personalizeRecipe = response.headers['x-personalize-recipe'];
 
-        if (experimentName || personalizeRecipe) {
-          const explanation = experimentName
-            ? `Active experiment: ${experimentName}`
-            : `Personalize recipe: ${personalizeRecipe}`;
-
-          this.explainRecommended = {
-            activeExperiment: !!experimentName,
-            personalized: !!personalizeRecipe,
-            explanation,
-          };
-        }
+        if (experimentName) this.experiment = `Active experiment: ${experimentName}`;
+        if (personalizeRecipe) this.demoGuideBadgeArticle = Articles.SIMILAR_ITEM_RECOMMENDATIONS;
       }
 
       this.relatedProducts = response.data;

--- a/src/web-ui/src/public/ProductDetail.vue
+++ b/src/web-ui/src/public/ProductDetail.vue
@@ -84,7 +84,7 @@ import RecommendedProductsSection from '@/components/RecommendedProductsSection/
 import { discountProductPrice } from '@/util/discountProductPrice';
 import DemoGuideBadge from '@/components/DemoGuideBadge/DemoGuideBadge';
 
-import { Articles } from '@/partials/AppModal/DemoGuide/config';
+import { getDemoGuideArticleFromPersonalizeARN } from '@/partials/AppModal/DemoGuide/config';
 
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
 const MAX_RECOMMENDATIONS = 6;
@@ -185,7 +185,7 @@ export default {
     async getRelatedProducts() {
       // reset in order to trigger recalculation in carousel - carousel UI breaks without this
       this.relatedProducts = null;
-      
+
       this.experiment = null;
       this.demoGuideBadgeArticle = null;
 
@@ -201,7 +201,7 @@ export default {
         const personalizeRecipe = response.headers['x-personalize-recipe'];
 
         if (experimentName) this.experiment = `Active experiment: ${experimentName}`;
-        if (personalizeRecipe) this.demoGuideBadgeArticle = Articles.SIMILAR_ITEM_RECOMMENDATIONS;
+        if (personalizeRecipe) this.demoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe);
       }
 
       this.relatedProducts = response.data;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes the demo guide badges dynamic based on the recipe returned by the section's request. Since this now has the same functionality as the inline recipe ARNs, those are removed. The same UI will still show if an experiment is active for now. 

Additionally, adds a demo guide badge on the category page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
