### PR TITLE
Constrain modal height

### DIFF
--- a/src/web-ui/src/partials/AppModal/Modal/Modal.vue
+++ b/src/web-ui/src/partials/AppModal/Modal/Modal.vue
@@ -83,5 +83,6 @@ export default {
 
 .modal-body {
   height: 800px;
+  max-height: 80vh;
 }
 </style>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On shorter screens desktop resolution screens, the main modal component causes scrolling. The height is now confined to fit on the screen without scrolling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
