### PR TITLE
Demo walkthrough mobile nav

### DIFF
--- a/src/web-ui/src/partials/AppModal/DemoWalkthrough/DemoWalkthrough.vue
+++ b/src/web-ui/src/partials/AppModal/DemoWalkthrough/DemoWalkthrough.vue
@@ -1,6 +1,10 @@
 <template>
-  <Modal :showHeader="false">
-    <template #body="{bodyClass}">
+  <Modal :showHeader="isMobile">
+    <template #header>
+      <ModalHeader class="demo-walkthrough-header"></ModalHeader>
+    </template>
+
+    <template #body="{ bodyClass }">
       <component :is="pages[currentPageIndex]" :class="bodyClass"></component>
     </template>
   </Modal>
@@ -10,6 +14,7 @@
 import { mapState } from 'vuex';
 
 import Modal from '../Modal/Modal';
+import ModalHeader from '../Modal/ModalHeader/ModalHeader';
 import Welcome from './pages/Welcome';
 import Overview from './pages/Overview';
 import Shoppers from './pages/Shoppers';
@@ -23,6 +28,7 @@ export default {
   name: 'DemoWalkthrough',
   components: {
     Modal,
+    ModalHeader,
   },
   data() {
     return {
@@ -39,7 +45,17 @@ export default {
     };
   },
   computed: {
-    ...mapState({ currentPageIndex: (state) => state.modal.openModal.pageIndex }),
+    ...mapState({
+      currentPageIndex: (state) => state.modal.openModal.pageIndex,
+      isMobile: (state) => state.modal.isMobile,
+    }),
   },
 };
 </script>
+
+<style scoped>
+.demo-walkthrough-header {
+  border-radius: 0;
+  background: var(--aws-deep-squid-ink);
+}
+</style>

--- a/src/web-ui/src/partials/AppModal/DemoWalkthrough/DemoWalkthroughPageLayout.vue
+++ b/src/web-ui/src/partials/AppModal/DemoWalkthrough/DemoWalkthroughPageLayout.vue
@@ -8,9 +8,11 @@
       v-if="showNav"
       :class="{ 'demo-walkthrough-nav d-flex justify-content-between': true, 'demo-walkthrough-nav--mobile': isMobile }"
     >
-      <button v-if="!isLast" class="end-tour btn btn-outline-primary" @click="skip">End Tour</button>
+      <button v-if="!isLast" class="end-tour end-tour--desktop-only btn btn-outline-primary" @click="skip">
+        End Tour
+      </button>
 
-      <div :class="{ 'ml-auto': isLast }">
+      <div :class="{ 'demo-walkthrough-nav__main': true, 'ml-auto': isLast }">
         <button class="prev btn btn-outline-primary" @click="prevTourPage">Previous</button>
 
         <button v-if="isLast" class="end-tour btn btn-primary ml-2" @click="skip">End Tour</button>
@@ -222,8 +224,9 @@ export default {
   padding-bottom: 0;
 }
 
-/* fixes inability to scroll on firefox */
 .main--mobile {
+  padding-top: 0;
+  /* fixes inability to scroll on firefox */
   padding-bottom: 100px;
 }
 
@@ -268,7 +271,16 @@ export default {
 .demo-walkthrough-nav--mobile .prev,
 .demo-walkthrough-nav--mobile .next {
   font-size: 1rem;
-  width: 90px;
+}
+
+.demo-walkthrough-nav--mobile .end-tour--desktop-only {
+  display: none;
+}
+
+.demo-walkthrough-nav--mobile .demo-walkthrough-nav__main {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
 }
 
 .arrow-svg {

--- a/src/web-ui/src/partials/AppModal/Modal/Modal.vue
+++ b/src/web-ui/src/partials/AppModal/Modal/Modal.vue
@@ -67,6 +67,12 @@ export default {
   border-radius: 0;
 }
 
+.modal-dialog {
+  width: 95%;
+  max-width: 1200px;
+  height: 90%;
+}
+
 .modal--mobile .modal-dialog {
   margin: 0;
   width: auto;
@@ -75,14 +81,12 @@ export default {
   max-height: none;
 }
 
-.modal-dialog {
-  width: 95%;
-  max-width: 1200px;
-  height: 90%;
-}
-
 .modal-body {
   height: 800px;
   max-height: 80vh;
+}
+
+.modal--mobile .modal-body {
+  max-height: none;
 }
 </style>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes demo walkthrough navigation button sizing on mobile by removing the "End tour" button on all but the last page and rendering a close button in the top right corner instead.

Also resolves a bug introduced in #166 which makes modals not take up the whole page in mobile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
