### PR TITLE
Fix Elasticsearch pre-index Lambda

### DIFF
--- a/aws/cloudformation-templates/deployment-support.yaml
+++ b/aws/cloudformation-templates/deployment-support.yaml
@@ -391,7 +391,7 @@ Resources:
         S3Bucket: !Ref ResourceBucket
         S3Key: !Sub '${ResourceBucketRelativePath}aws-lambda/elasticsearch-pre-index.zip'
       Runtime: python3.8
-      Timeout: 900
+      Timeout: 300
       VpcConfig:
         SecurityGroupIds:
           - !Ref ElasticsearchSecurityGroupId

--- a/aws/cloudformation-templates/deployment-support.yaml
+++ b/aws/cloudformation-templates/deployment-support.yaml
@@ -391,7 +391,7 @@ Resources:
         S3Bucket: !Ref ResourceBucket
         S3Key: !Sub '${ResourceBucketRelativePath}aws-lambda/elasticsearch-pre-index.zip'
       Runtime: python3.8
-      Timeout: 60
+      Timeout: 900
       VpcConfig:
         SecurityGroupIds:
           - !Ref ElasticsearchSecurityGroupId
@@ -432,8 +432,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*ElasticsearchPreIndexLambdaFunction*:log-stream:*'
-                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*ElasticsearchPreIndexLambdaFunction*'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*Elasticsearch*:log-stream:*'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*Elasticsearch*'
               - Effect: Allow
                 Action:
                   - es:ESHttpDelete

--- a/src/aws-lambda/elasticsearch-pre-index/bundle.sh
+++ b/src/aws-lambda/elasticsearch-pre-index/bundle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 
 LAMBDA_SOURCE=elasticsearch-pre-index.py
 PACKAGE_FILE=elasticsearch-pre-index.zip
@@ -9,7 +9,7 @@ echo "Cleaning up intermediate files"
 [ -e "package" ] && rm -rf package
 
 echo "Installing Lambda dependencies"
-pip install --target ./package requests pyyaml crhelper
+pip install -r requirements.txt --target ./package
 
 echo "Building Lambda deployment package"
 cd package
@@ -18,6 +18,5 @@ cd ${OLDPWD}
 
 echo "Adding Lambda function source code to package"
 zip -g ${PACKAGE_FILE} ${LAMBDA_SOURCE}
-
 
 echo "Done!"

--- a/src/aws-lambda/elasticsearch-pre-index/requirements.txt
+++ b/src/aws-lambda/elasticsearch-pre-index/requirements.txt
@@ -1,0 +1,3 @@
+crhelper
+elasticsearch>=7.0.0,<8.0.0
+pyyaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Elasticsearch pre-index Lambda (custom resource) was timing out indexing the new (larger) product catalog introduced in #159. 

- Increased function timeout from 1 minute to 5 minutes (testing was taking just over 1 minute so added buffer to support future expansion of catalog).
- Fix IAM role for function so that CW logs could be written. This will help with future debugging.
- Rather than indexing products one at a time, switched to bulk indexing to speed up overall process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
