### PR TITLE
Reset category filters on navigation to different category

### DIFF
--- a/src/web-ui/src/public/CategoryDetail.vue
+++ b/src/web-ui/src/public/CategoryDetail.vue
@@ -128,6 +128,7 @@ export default {
     async getProductsByCategory(categoryName) {
       this.demoGuideBadgeArticle = null
       this.experiment = null
+      this.products = []
 
       let intermediate = null
       if (categoryName == 'featured') {
@@ -205,8 +206,12 @@ export default {
     }
   },
   watch: {
-    // call again the method if the route changes
-    '$route': 'fetchData'
+    $route() {
+      this.selectedGenders = [];
+      this.selectedStyles = [];
+
+      this.fetchData();
+    },
   },
 }
 </script>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Filters are not being cleared on route change so they are retained if you switch to a different category. 

Also replaces page content with loading indicator when switching from one category to another.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
