### PR TITLE
Increase products per row on mobile

### DIFF
--- a/src/web-ui/src/public/Main.vue
+++ b/src/web-ui/src/public/Main.vue
@@ -205,6 +205,13 @@ export default {
 .user-recommendations {
   display: grid;
   grid-gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+}
+
+@media (min-width: 768px) {
+.user-recommendations {
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
 }
 </style>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes it so you can see 2 products per row on mobile screens in the personalized recommendations section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
