### PR TITLE
Fix timeouts indexing products and optimize loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/aws-lambda/*/package
 src/aws-lambda/elasticsearch-pre-index/products.yaml
 src/aws-lambda/personalize-delete-resources/models
 src/aws-lambda/personalize-pre-create-campaigns/models
+src/aws-lambda/personalize-pre-create-campaigns/data
 src/aws-lambda/pinpoint-auto-workshop/pinpoint-templates
 local/*
 demo.md
@@ -26,3 +27,4 @@ generators/*.gz
 workshop/data/*
 workshop/datagenerator/*
 workshop/requirements.txt
+workshop/1-Personalization/generate_interactions_personalize.py

--- a/src/aws-lambda/elasticsearch-pre-index/elasticsearch-pre-index.py
+++ b/src/aws-lambda/elasticsearch-pre-index/elasticsearch-pre-index.py
@@ -46,7 +46,8 @@ def elasticsearch_create(event,_):
     # For testing: specify 'ForceIndex' to force existing index to be deleted and products indexed.
     force_index = event['ResourceProperties'].get('ForceIndex', 'no').lower() in [ 'true', 'yes', '1' ]
 
-    es = Elasticsearch(hosts = [es_host])
+    es = Elasticsearch(hosts = [es_host], timeout=30, max_retries=10, retry_on_timeout=True)
+
     create_index_and_bulk_load = True
 
     if es.indices.exists(INDEX_NAME):

--- a/src/aws-lambda/retaildemostore-lambda-load-products/src/main.go
+++ b/src/aws-lambda/retaildemostore-lambda-load-products/src/main.go
@@ -161,7 +161,7 @@ func loadData(s3bucket, s3file, ddbtable, datatype string) (string, error) {
 // HandleRequest - handles Lambda request
 func HandleRequest(ctx context.Context, event cfn.Event) (physicalResourceID string, data map[string]interface{}, err error) {
 
-	if event.RequestType == "Create" {
+	if event.RequestType == "Create" || event.RequestType == "Update" {
 		Bucket, _ := event.ResourceProperties["Bucket"].(string)
 		File, _ := event.ResourceProperties["File"].(string)
 		Table, _ := event.ResourceProperties["Table"].(string)

--- a/src/aws-lambda/retaildemostore-lambda-load-products/src/main.go
+++ b/src/aws-lambda/retaildemostore-lambda-load-products/src/main.go
@@ -45,10 +45,10 @@ type Products []Product
 
 // Category Struct
 type Category struct {
-	ID    string `json:"id" yaml:"id"`
-	Name  string `json:"name" yaml:"name"`
-	Image string `json:"image" yaml:"image"`
-	HasGenderAffinity bool `json:"has_gender_affinity" yaml:"has_gender_affinity"`
+	ID                string `json:"id" yaml:"id"`
+	Name              string `json:"name" yaml:"name"`
+	Image             string `json:"image" yaml:"image"`
+	HasGenderAffinity bool   `json:"has_gender_affinity" yaml:"has_gender_affinity"`
 }
 
 // Categories Array
@@ -160,15 +160,20 @@ func loadData(s3bucket, s3file, ddbtable, datatype string) (string, error) {
 
 // HandleRequest - handles Lambda request
 func HandleRequest(ctx context.Context, event cfn.Event) (physicalResourceID string, data map[string]interface{}, err error) {
-	Bucket, _ := event.ResourceProperties["Bucket"].(string)
-	File, _ := event.ResourceProperties["File"].(string)
-	Table, _ := event.ResourceProperties["Table"].(string)
-	Datatype, _ := event.ResourceProperties["Datatype"].(string)
 
-	log.Println("Importing ", Bucket, File, " to ", Table, Datatype)
-	returnstring, err = loadData(Bucket, File, Table, Datatype)
-	data = map[string]interface{}{"return": returnstring}
-	return returnstring, data, err
+	if event.RequestType == "Create" {
+		Bucket, _ := event.ResourceProperties["Bucket"].(string)
+		File, _ := event.ResourceProperties["File"].(string)
+		Table, _ := event.ResourceProperties["Table"].(string)
+		Datatype, _ := event.ResourceProperties["Datatype"].(string)
+
+		log.Println("Importing ", Bucket, File, " to ", Table, Datatype)
+		returnstring, err = loadData(Bucket, File, Table, Datatype)
+		data = map[string]interface{}{"return": returnstring}
+		return returnstring, data, err
+	}
+
+	return "", map[string]interface{}{}, nil
 }
 
 func main() {


### PR DESCRIPTION
*Description of changes:*

Resolving some recurring issues with deployments.

- When pre-indexing in Elasticsearch is selected, the lambda would sometimes timeout when the ES server would need to merge segments or the JVM would GC. The client now has a longer timeout and will retry. This should make this lambda more reliable.
- The custom resource lambda that loaded products in DDB was loading them for all CFN event types. Now it only loads on "Create" event types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
