### PR TITLE
update cart service and FE to use common REST API urls

### DIFF
--- a/src/carts/src/carts-service/routes.go
+++ b/src/carts/src/carts-service/routes.go
@@ -26,13 +26,13 @@ var routes = Routes{
 	Route{
 		"CartsIndex",
 		"GET",
-		"/carts/all",
+		"/carts",
 		CartIndex,
 	},
 	Route{
 		"CartShowByID",
 		"GET",
-		"/carts/id/{cartID}",
+		"/carts/{cartID}",
 		CartShowByID,
 	},
 	Route{
@@ -50,13 +50,13 @@ var routes = Routes{
 	Route{
 		"CartUpdate",
 		"PUT",
-		"/carts/id/{cartID}",
+		"/carts/{cartID}",
 		CartUpdate,
 	},
 	Route{
 		"CartUpdate",
 		"OPTIONS",
-		"/carts/id/{cartID}",
+		"/carts/{cartID}",
 		CartUpdate,
 	},
 }

--- a/src/products/src/products-service/go.mod
+++ b/src/products/src/products-service/go.mod
@@ -1,7 +1,9 @@
 module products
 
-go 1.14
+go 1.15
 
-require github.com/gorilla/mux master
-require gopkg.in/yaml.v2 master
-require github.com/google/uuid master
+require (
+	github.com/gorilla/mux v1.8.0
+	gopkg.in/yaml.v2 v2.4.0
+	github.com/google/uuid v1.1.5
+)

--- a/src/web-ui/src/repositories/cartsRepository.js
+++ b/src/web-ui/src/repositories/cartsRepository.js
@@ -14,12 +14,12 @@ const connection = axios.create({
 const resource = "/carts";
 export default {
     get() {
-        return connection.get(`${resource}/all`)
+        return connection.get(`${resource}`)
     },
     getCartByID(cartID) {
         if (!cartID || cartID.length == 0)
             throw "cartID required"
-        return connection.get(`${resource}/id/${cartID}`)
+        return connection.get(`${resource}/${cartID}`)
     },    
     createCart(username) {
         if (!username || username.length == 0)
@@ -32,6 +32,6 @@ export default {
     updateCart(cart) {
         if (!cart)
             throw "cart required"
-        return connection.put(`${resource}/id/${cart.id}`, cart)
+        return connection.put(`${resource}/${cart.id}`, cart)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#158

*Description of changes:*

As mentioned in the above issue, this pull requests makes the URLs in the cart service follow the standard pattern used by REST APIs. I have not changed the `cart/{id}` endpoint to return a 404 when no cart is found because it appears the frontend relies on the the object with a null `items` field returned when a cart is not found immediately after submitting an order. I will do the products service as soon as this PR is merged to minimise the amount of time where the APIs across the services are inconsistent.

I also updated the `go.mod` file because the container uses v1.15 of Go but the file format was for v1.14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
