### PR TITLE
hot-fix videos x-ray support

### DIFF
--- a/src/videos/src/videos-service/app.py
+++ b/src/videos/src/videos-service/app.py
@@ -8,6 +8,8 @@ from aws_xray_sdk.core import patch_all
 
 patch_all()
 
+xray_recorder.begin_segment("Videos-init")
+
 import logging
 import json
 import os


### PR DESCRIPTION
*Issue #, if available:* #212 

*Description of changes:* AWS X-ray need to start a segment before any downstream call.
The video service is calling AWS service in the init phase, so forcing a `begin_segment` is required


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
