### PR TITLE
Bug fix for the Amazon Pinpoint - Abandoned Cart Campaign section.

### DIFF
--- a/src/web-ui/src/analytics/AnalyticsHandler.js
+++ b/src/web-ui/src/analytics/AnalyticsHandler.js
@@ -251,9 +251,6 @@ export const AnalyticsHandler = {
         if (user && cart && cartProduct) {
             AmplifyAnalytics.record({
                 name: '_session.stop',
-                attributes: {
-                    HasShoppingCart: cart.items.length > 0 ? ['true'] : ['false'],
-                }
             })
 
         return AmplifyAnalytics.updateEndpoint({

--- a/workshop/4-Messaging/4.1-Pinpoint.ipynb
+++ b/workshop/4-Messaging/4.1-Pinpoint.ipynb
@@ -904,7 +904,7 @@
    "source": [
     "### Abandoned Cart Campaign\n",
     "\n",
-    "To create an abandoned cart campaign, repeat the steps you followed for the Welcome campaign above but this time select the `UsersWithCarts` segment, the `RetailDemoStore-AbandonedCart` email template, and the `Session Stop` event. This will trigger the abandoned cart email to be sent when users end their session while still having a shopping cart. Launch the campaign, wait for the campaign to start, and then close out some browser sessions for user(s) with items still in their cart. This can take some trial and error and waiting given the how browsers and devices trigger end of session events."
+    "To create an abandoned cart campaign, repeat the steps you followed for the Welcome campaign above but this time select the `UsersWithCarts` segment, the `RetailDemoStore-AbandonedCart` email template, and the `_session.stop` event. This will trigger the abandoned cart email to be sent when users end their session while still having a shopping cart. Launch the campaign, wait for the campaign to start, and then close out some browser sessions for user(s) with items still in their cart. This can take some trial and error and waiting given the how browsers and devices trigger end of session events."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

Amazon Pinpoint returns the error 400 response when clicking on the "Trigger Abandoned Cart email" button.

*Description of changes:*

Remove the unnecessary attribute causing Amazon Pinpoint to throw the error and update the Jupyter notebook with the correct event name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
