### PR TITLE
Identity sync fix

### DIFF
--- a/src/aws-lambda/bot-intent-recommendations/bot-intent-recommendations.py
+++ b/src/aws-lambda/bot-intent-recommendations/bot-intent-recommendations.py
@@ -66,7 +66,7 @@ def lookup_user(identity_id):
 
     url = f'{users_service_base_url}/users/identityid/{identity_id}'
     response = requests.get(url)
-    
+
     user = None
 
     if response.ok:
@@ -84,7 +84,7 @@ def get_recommendations(user_id, max_items = 10):
 
     url = f'{recommendations_service_base_url}/recommendations?userID={user_id}&fullyQualifyImageUrls=1&numResults={max_items}'
     response = requests.get(url)
-    
+
     recommendations = None
 
     if response.ok:
@@ -94,21 +94,18 @@ def get_recommendations(user_id, max_items = 10):
     return recommendations
 
 def recommend_products(intent_request):
-    user_id = intent_request['userId']
-    output_session_attributes = intent_request['sessionAttributes'] if intent_request['sessionAttributes'] is not None else {}
+    # What the chatbot sends as the "userId" is really the identity ID from the auth'd client session.
+    identity_id = intent_request['userId']
 
-    store_user = None
-    if output_session_attributes.get('storeUser'):
-        store_user = json.loads(output_session_attributes.get('storeUser'))
-        logger.debug('Found user {} ({}) as session attribute'.format(store_user['username'], store_user['id']))
-
-    if not store_user:
-        store_user = lookup_user(user_id)
-        if store_user:
-            output_session_attributes['storeUser'] = json.dumps(store_user)
+    # Lookup the user based on the identity_id
+    store_user = lookup_user(identity_id)
 
     if store_user:
         recommendations = get_recommendations(store_user['id'], 4)
+
+        user_name = store_user['first_name']
+        if not user_name:
+            user_name = "there"
 
         if recommendations and len(recommendations) > 0:
             attachments = []
@@ -118,21 +115,20 @@ def recommend_products(intent_request):
                 attachments.append(build_response_card_attachment(product['name'], product['description'], product['image'], product['url']))
 
             response = {
-                'sessionAttributes': output_session_attributes,
                 'dialogAction': {
                     'type': 'Close',
                     'fulfillmentState': 'Fulfilled',
                     'message': {
                         'contentType': 'PlainText',
-                        'content': 'Hi {}. Based on your shopping trends, I think you may be interested in the following products.'.format(store_user['first_name'])
+                        'content': 'Hi {}. Based on your shopping trends, I think you may be interested in the following products.'.format(user_name)
                     },
                     'responseCard': build_response_card(attachments)
                 }
             }
         else:
-            response = close(output_session_attributes, 'Failed', 'Sorry, I was unable to find any products to recommend.')
+            response = close('Failed', 'Sorry, I was unable to find any products to recommend.')
     else:
-        response = close(output_session_attributes, 'Failed', 'Before I can make personalized recommendations, I need to know more about you. Please sign in or create an account and try again.')
+        response = close('Failed', 'Before I can make personalized recommendations, I need to know more about you. Please sign in or create an account and try again.')
 
     return response
 

--- a/src/web-ui/src/router/index.js
+++ b/src/web-ui/src/router/index.js
@@ -58,9 +58,9 @@ AmplifyEventBus.$on('authState', async (state) => {
   if (state === 'signedOut') {
     AmplifyStore.dispatch('logout');
     AnalyticsHandler.clearUser()
-    
+
     if (router.currentRoute.path !== '/') router.push({ path: '/' })
-  } 
+  }
   else if (state === 'signedIn') {
     const cognitoUser = await getCognitoUser()
 
@@ -89,7 +89,7 @@ AmplifyEventBus.$on('authState', async (state) => {
     }
 
     console.log('Syncing store user state to cognito user custom attributes')
-    // Store user exists. Use this as opportunity to sync store user 
+    // Store user exists. Use this as opportunity to sync store user
     // attributes to Cognito custom attributes.
     await Vue.prototype.$Amplify.Auth.updateUserAttributes(cognitoUser, {
       'custom:profile_user_id': storeUser.id.toString(),
@@ -106,7 +106,7 @@ AmplifyEventBus.$on('authState', async (state) => {
       console.log('Syncing credentials identity_id with store user profile')
       storeUser.identity_id = credentials.identityId
     }
-    
+
     // Update last sign in and sign up dates on user.
     let newSignUp = false
 
@@ -118,10 +118,10 @@ AmplifyEventBus.$on('authState', async (state) => {
       newSignUp = true
     }
 
-    // Wait for identify to complete before sending sign in/up events 
+    // Wait for identify to complete before sending sign in/up events
     // so that endpoint is created/updated first. Impacts Pinpoint campaign timing.
     await AnalyticsHandler.identify(storeUser)
-    
+
     // Fire sign in and first time sign up events.
     AnalyticsHandler.userSignedIn(storeUser)
 
@@ -136,7 +136,7 @@ AmplifyEventBus.$on('authState', async (state) => {
 
     if (newSignUp && !hasAssignedShopperProfile) {
       AmplifyStore.dispatch('firstTimeSignInDetected');
-      
+
       router.push({path: '/shopper-select'});
     } else {
       router.push({path: '/'});
@@ -147,7 +147,7 @@ AmplifyEventBus.$on('authState', async (state) => {
     const storeUser = AmplifyStore.state.user
 
     if (cognitoUser && storeUser) {
-      // Store user exists. Use this as opportunity to sync store user 
+      // Store user exists. Use this as opportunity to sync store user
       // attributes to Cognito custom attributes.
       Vue.prototype.$Amplify.Auth.updateUserAttributes(cognitoUser, {
         'custom:profile_user_id': storeUser.id.toString(),
@@ -158,6 +158,14 @@ AmplifyEventBus.$on('authState', async (state) => {
         'custom:profile_age': storeUser.age.toString(),
         'custom:profile_persona': storeUser.persona
       })
+    }
+
+    // Sync identityId with user to support reverse lookup.
+    const credentials = await Credentials.get();
+    if (credentials && storeUser.identity_id != credentials.identityId) {
+      console.log('Syncing credentials identity_id with store user profile')
+      storeUser.identity_id = credentials.identityId
+      UsersRepository.updateUser(storeUser)
     }
   }
 });
@@ -193,7 +201,7 @@ const router = new Router({
       component: ProductDetail,
       props: route => ({ discount: route.query.di === "true" || route.query.di === true}),
       meta: { requiresAuth: false}
-    },  
+    },
     {
       path: '/category/:id',
       name: 'CategoryDetail',
@@ -211,19 +219,19 @@ const router = new Router({
       name: 'Help',
       component: Help,
       meta: { requiresAuth: false}
-    },       
+    },
     {
       path: '/orders',
       name: 'Orders',
       component: Orders,
       meta: { requiresAuth: true}
-    },  
+    },
     {
       path: '/cart',
       name: 'Cart',
       component: Cart,
       meta: { requiresAuth: false}
-    },    
+    },
     {
       path: '/checkout',
       name: 'Checkout',
@@ -235,7 +243,7 @@ const router = new Router({
       name: 'Admin',
       component: Admin,
       meta: { requiresAuth: true}
-    },      
+    },
     {
       path: '/auth',
       name: 'Authenticator',
@@ -269,7 +277,7 @@ router.beforeResolve(async (to, from, next) => {
       AmplifyStore.dispatch('welcomePageVisited');
       return next('/welcome');
     }
-  }     
+  }
 
   if (to.matched.some(record => record.meta.requiresAuth)) {
     const user = await getUser();


### PR DESCRIPTION
*Issue #, if available:*

Closes #232 

*Description of changes:*

- Added logic to the `profileChanged` state change handler to update the sync the entityId from the auth'd session with the newly selected shopper/user. This will ensure the reverse lookup done in the lex chatbot handler (lambda) can find the right shopper/user.
- Remove the caching of the user in the lex session in case the end-user changes to another shopper. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
