### PR TITLE
Make Segment resources optional

### DIFF
--- a/aws/cloudformation-templates/event-engine/base-workshop.yaml
+++ b/aws/cloudformation-templates/event-engine/base-workshop.yaml
@@ -2,35 +2,35 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Description: >
-  This template deploys the base Retail Demo Store project and workshop notebooks in the Event Engine. 
+  This template deploys the base Retail Demo Store project and workshop notebooks in the Event Engine.
   MUST BE DEPLOYED IN THE SAME REGION AS THE ResourceBucket PARAMETER BELOW!
 
 Parameters:
   ResourceBucket:
     Type: String
     Description: >
-      S3 bucket name where the Retail Demo Store deployment resources are staged (product images, nested CloudFormation templates, source code snapshot, 
+      S3 bucket name where the Retail Demo Store deployment resources are staged (product images, nested CloudFormation templates, source code snapshot,
       notebooks, deployment Lambda code, etc).
-    # This is the Retail Demo Store project's standard staging bucket for deployments into us-east-1. The contents in this 
-    # bucket are always kept in sync with the latest from the upstream Retail Demo Store GH repo. If you want to deploy custom 
-    # coding changes, data files, custom nested CFN templates, or whatever for your workshop, you will need to stage ALL required 
-    # deployment resources to a public S3 bucket (or to the EEAssetsBucket for your EE module) and change the default value 
-    # below to match your bucket. The stage.sh script in the root of the Retail Demo Store repo can be used to stage these 
-    # resources. See the documentation in the GH repo for details. As noted above, the region of your staging bucket must 
+    # This is the Retail Demo Store project's standard staging bucket for deployments into us-east-1. The contents in this
+    # bucket are always kept in sync with the latest from the upstream Retail Demo Store GH repo. If you want to deploy custom
+    # coding changes, data files, custom nested CFN templates, or whatever for your workshop, you will need to stage ALL required
+    # deployment resources to a public S3 bucket (or to the EEAssetsBucket for your EE module) and change the default value
+    # below to match your bucket. The stage.sh script in the root of the Retail Demo Store repo can be used to stage these
+    # resources. See the documentation in the GH repo for details. As noted above, the region of your staging bucket must
     # match the region where you're deploying your event in Event Engine.
     Default: 'retail-demo-store-us-east-1'
 
   ResourceBucketRelativePath:
     Type: String
     Description: >
-      Optional path in the Deployment Resources Staging bucket where the deployment resources are stored (e.g. path/path2/). 
+      Optional path in the Deployment Resources Staging bucket where the deployment resources are stored (e.g. path/path2/).
       Leave blank if resources are at the root of the Staging Resource Bucket. If specified, MUST end with '/'.
     Default: ''
-  
+
 Resources:
   # This references the root template.yaml file that comes with the Retail Demo Store. The parameters passed to this template
-  # are set to sensible default values for a base Retail Demo Store workshop experience. Change them as needed in your own 
-  # Event Engine blueprint and module. Happy Eventing. 
+  # are set to sensible default values for a base Retail Demo Store workshop experience. Change them as needed in your own
+  # Event Engine blueprint and module. Happy Eventing.
   ee:   # Keep the resource name short to avoid name length issues in nested template resources
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -53,6 +53,7 @@ Resources:
         PinpointSMSLongCode: 'NONE'
         AmplitudeApiKey: 'NONE'
         OptimizelySdkKey: 'NONE'
+        IncludeSegmentDependencies: 'No' # Change to 'Yes' for Segment workshop
         SegmentWriteKey: 'NONE'
 
 Outputs:

--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -43,6 +43,7 @@ Metadata:
         Parameters:
           - AmplitudeApiKey
           - OptimizelySdkKey
+          - IncludeSegmentDependencies
           - SegmentWriteKey
     ParameterLabels:
       ResourceBucket:
@@ -72,11 +73,13 @@ Metadata:
       PinpointEmailFromName:
         default: "Reply-To name"
       UseDefaultIVSStreams:
-        default: "Use default IVS streams"
+        default: "Use Default IVS Streams"
       AmplitudeApiKey:
         default: "Amplitude API Key"
       OptimizelySdkKey:
         default: "Optimizely SDK Key"
+      IncludeSegmentDependencies:
+        default: "Deploy Segment Resources"
       SegmentWriteKey:
         default: "Segment Write Key"
 
@@ -208,10 +211,25 @@ Parameters:
     Description: Optimizely SDK key for experimentation (optional).
     NoEcho: true
 
+  IncludeSegmentDependencies:
+    Type: String
+    Description: >
+      Whether to deploy the resources required for the Segment workshops.
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+
   SegmentWriteKey:
     Type: String
-    Description: Segment write key for real-time data collection (optional).
+    Description: >
+      Segment write key for real-time data collection (optional). Be sure the Segment resources are deployed (above) if you specify a write key.
     NoEcho: true
+
+Conditions:
+  DeploySegmentResources: !Equals
+    - !Ref IncludeSegmentDependencies
+    - 'Yes'
 
 Resources:
   # Base Resources
@@ -348,8 +366,9 @@ Resources:
     Properties:
       TemplateURL: !Sub https://s3.amazonaws.com/${ResourceBucket}/${ResourceBucketRelativePath}cloudformation-templates/cleanup-bucket.yaml
 
-  # Segment Lambda Function
+  # Segment Lambda Functions and Roles
   SegmentPersonalize:
+    Condition: DeploySegmentResources
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub https://s3.amazonaws.com/${ResourceBucket}/${ResourceBucketRelativePath}cloudformation-templates/segment.yaml


### PR DESCRIPTION
*Description of changes:*

Added CloudFormation template parameter to conditionally deploy Segment resources (Lambda functions and associated roles) so that internal AWS deployments can skip Segment and avoid role audit alerts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
