### PR TITLE
When we get an internal server exception in the IVS streaming server …

### DIFF
--- a/src/videos/src/videos-service/app.py
+++ b/src/videos/src/videos-service/app.py
@@ -140,6 +140,11 @@ def is_ssm_parameter_set(parameter_name):
         return False
 
 
+def log_ffmpeg_processes():
+    app.logger.info('Running ffmpeg processes:')
+    app.logger.info(os.system("ps aux|grep 'PID\|ffmpeg'"))
+
+
 def put_ivs_metadata(channel_arn, line):
     """
         Sends metadata to a given IVS stream. Metadata can be any string, but the AWS Retail Demo Store UI expects
@@ -151,11 +156,14 @@ def put_ivs_metadata(channel_arn, line):
             channelArn=channel_arn,
             metadata=line
         )
-    except ivs_client.exceptions.ChannelNotBroadcasting:
-        app.logger.warning(f'Channel not broadcasting. Waiting for 5 seconds.')
-        app.logger.info('Running ffmpeg processes:')
-        app.logger.info(os.system("ps aux|grep 'PID\|ffmpeg'"))
+    except ivs_client.exceptions.ChannelNotBroadcasting as ex:
+        app.logger.warning(f'Channel not broadcasting. Waiting for 5 seconds. Exception: {ex}')
+        log_ffmpeg_processes()
         time.sleep(5)
+    except ivs_client.exceptions.InternalServerException as ex:
+        app.logger.error(f'We have an internal error exception. Waiting for 30 seconds. Exception: {ex}')
+        log_ffmpeg_processes()
+        time.sleep(30)
 
 
 def get_stream_state(channel_arn):


### PR DESCRIPTION
When we get an internal server exception in the IVS streaming server we want the
IVS streaming server to keep running.

 -----
  This work was done by Dae.mn Team. http://dae.mn/ml
  Damien.Duff@dae.mn Joe.Major@dae.mn Kyle.Redelinghuys@dae.mn



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
