### PR TITLE
Disable ES SLR for base EE template

### DIFF
--- a/aws/cloudformation-templates/event-engine/base-workshop.yaml
+++ b/aws/cloudformation-templates/event-engine/base-workshop.yaml
@@ -2,7 +2,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Description: >
-  This template deploys the base Retail Demo Store project and workshop notebooks in the Event Engine.
+  This template deploys the base Retail Demo Store project and workshop notebooks in Event Engine.
   MUST BE DEPLOYED IN THE SAME REGION AS THE ResourceBucket PARAMETER BELOW!
 
 Parameters:
@@ -11,7 +11,7 @@ Parameters:
     Description: >
       S3 bucket name where the Retail Demo Store deployment resources are staged (product images, nested CloudFormation templates, source code snapshot,
       notebooks, deployment Lambda code, etc).
-    # This is the Retail Demo Store project's standard staging bucket for deployments into us-east-1. The contents in this
+    # This is the Retail Demo Store project's standard staging bucket for deployments in us-east-1. The contents in this
     # bucket are always kept in sync with the latest from the upstream Retail Demo Store GH repo. If you want to deploy custom
     # coding changes, data files, custom nested CFN templates, or whatever for your workshop, you will need to stage ALL required
     # deployment resources to a public S3 bucket (or to the EEAssetsBucket for your EE module) and change the default value
@@ -28,9 +28,12 @@ Parameters:
     Default: ''
 
 Resources:
-  # This references the root template.yaml file that comes with the Retail Demo Store. The parameters passed to this template
-  # are set to sensible default values for a base Retail Demo Store workshop experience. Change them as needed in your own
-  # Event Engine blueprint and module. Happy Eventing.
+  # This references the root template.yaml file that comes with the Retail Demo Store as a nested template. The parameters passed
+  # to this template are set to sensible default values for a base Retail Demo Store workshop experience. If you want to run an
+  # event with different template parameter values than these, create your own blueprint and module in Event Engine, use this
+  # file/template as your team template, and adjust values as needed. Be sure to leave "CreateElasticsearchServiceLinkedRole" set
+  # to "No" below and add "es.amazonaws.com" to the "IAM Service Linked Roles" in your Event Engine template so EE will conditionally
+  # create this role for you. Happy Eventing.
   ee:   # Keep the resource name short to avoid name length issues in nested template resources
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -38,7 +41,7 @@ Resources:
       Parameters:
         ResourceBucket: !Ref ResourceBucket
         ResourceBucketRelativePath: !Ref ResourceBucketRelativePath
-        CreateElasticsearchServiceLinkedRole: 'Yes' # DO NOT CHANGE
+        CreateElasticsearchServiceLinkedRole: 'No' # DO NOT CHANGE - should be managed by EE module in the "IAM Service Linked Roles" field
         SourceDeploymentType: 'CodeCommit' # DO NOT CHANGE
         GitHubRepo: 'retail-demo-store' # N/A SO DO NOT CHANGE
         GitHubBranch: 'master' # N/A SO DO NOT CHANGE


### PR DESCRIPTION
*Description of changes:*

- Disable creating the Elasticsearch service-linked role in the base Event Engine template.
- Update documentation in the base Event Engine template to refer to using Event Engine to manage creation of the ES SLR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
