### PR TITLE
Do not open a websocket when notifications are not enabled.

### DIFF
--- a/src/web-ui/src/public/Notifications.vue
+++ b/src/web-ui/src/public/Notifications.vue
@@ -29,6 +29,11 @@ export default {
       this.cognitoUser = await Auth.currentAuthenticatedUser()
     },
     openWebsocketConnection() {
+
+      if (!this.notificationsEnabled) {
+        return
+      }
+
       this.connection = new WebSocket(`${process.env.VUE_APP_LOCATION_NOTIFICATION_URL}?userId=${this.cognitoUser.username}`)
 
       this.connection.onopen = (e) => {
@@ -124,6 +129,13 @@ export default {
     },
     user() {
       return AmplifyStore.state.user
+    },
+    notificationsEnabled() {
+      const enabled = process.env.VUE_APP_LOCATION_NOTIFICATION_URL && process.env.VUE_APP_LOCATION_NOTIFICATION_URL !== ''
+      if (enabled) {
+        console.log('Websocket notifications are enabled')
+      }
+      return enabled
     }
   },
   watch: {


### PR DESCRIPTION
*Issue #, if available:* When Location Service Demo is not enabled, notification websockets do not deploy but UI gives an ugly error message.

*Description of changes:* Do not give the error message if websocket info not available to the UI.


-----
This work was done by the Dae.mn Team. http://dae.mn/ml
Damien.Duff@dae.mn Joe.Major@dae.mn Kyle.Redelinghuys@dae.mn


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
