### PR TITLE
Fixes malformed yaml error.

### DIFF
--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -264,8 +264,8 @@ Parameters:
   AmazonPayStoreId:
     Type: String
     Description: >
-    The Store ID of the Amazon Pay sandbox account being used.
-    For more information see "Amazon Pay Integration" under the README file in the amazon-pay-signing subfolder in the repository.
+      The Store ID of the Amazon Pay sandbox account being used.
+      For more information see "Amazon Pay Integration" under the README file in the amazon-pay-signing subfolder in the repository.
 
   AmazonPayMerchantId:
     Type: String


### PR DESCRIPTION
The description in AmazonPayStoreId had missing indents that rendered the yaml template invalid.

*Issue #, if available:*

*Description of changes:*
Changed indents in the template.yaml.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
