### PR TITLE
Product multi-item fetch optimization

### DIFF
--- a/aws/cloudformation-templates/base/tables.yaml
+++ b/aws/cloudformation-templates/base/tables.yaml
@@ -3,34 +3,23 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Description: >
     This template deploys the Retail Demo Store DynamoDB Tables.
-    
+
 Resources:
 
   ProductsTable:
     Type: AWS::DynamoDB::Table
-    Properties: 
-      AttributeDefinitions: 
+    Properties:
+      AttributeDefinitions:
         - AttributeName: "id"
           AttributeType: "S"
         - AttributeName: "category"
           AttributeType: "S"
         - AttributeName: "featured"
           AttributeType: "S"
-      KeySchema: 
+      KeySchema:
         - AttributeName: "id"
           KeyType: "HASH"
-        - AttributeName: "category"
-          KeyType: "RANGE"
       BillingMode: "PAY_PER_REQUEST"
-      LocalSecondaryIndexes:
-        - IndexName: id-featured-index
-          KeySchema:
-            - AttributeName: "id"
-              KeyType: "HASH"
-            - AttributeName: "featured"
-              KeyType: "RANGE"
-          Projection:
-            ProjectionType: ALL
       GlobalSecondaryIndexes:
         - IndexName: category-index
           KeySchema:
@@ -38,17 +27,23 @@ Resources:
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
+        - IndexName: featured-index
+          KeySchema:
+            - AttributeName: "featured"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: ALL
 
   CategoriesTable:
     DependsOn: ProductsTable
     Type: AWS::DynamoDB::Table
-    Properties: 
-      AttributeDefinitions: 
+    Properties:
+      AttributeDefinitions:
         - AttributeName: "id"
           AttributeType: "S"
         - AttributeName: "name"
           AttributeType: "S"
-      KeySchema: 
+      KeySchema:
         - AttributeName: "id"
           KeyType: "HASH"
       BillingMode: "PAY_PER_REQUEST"
@@ -63,33 +58,33 @@ Resources:
   ExperimentStrategyTable:
     Type: AWS::DynamoDB::Table
     DependsOn: "ProductsTable"
-    Properties: 
-      AttributeDefinitions: 
-        - 
+    Properties:
+      AttributeDefinitions:
+        -
           AttributeName: "id"
           AttributeType: "S"
-        - 
+        -
           AttributeName: "feature"
           AttributeType: "S"
-        - 
+        -
           AttributeName: "name"
           AttributeType: "S"
-      KeySchema: 
-        - 
+      KeySchema:
+        -
           AttributeName: "id"
           KeyType: "HASH"
       BillingMode: "PAY_PER_REQUEST"
-      GlobalSecondaryIndexes: 
-        - 
+      GlobalSecondaryIndexes:
+        -
           IndexName: "feature-name-index"
-          KeySchema: 
-            - 
+          KeySchema:
+            -
               AttributeName: "feature"
               KeyType: "HASH"
-            - 
+            -
               AttributeName: "name"
               KeyType: "RANGE"
-          Projection: 
+          Projection:
             ProjectionType: "ALL"
 
 Outputs:
@@ -98,7 +93,7 @@ Outputs:
     Description: DynamoDB Table for Products
     Value: !Ref ProductsTable
 
-  CategoriesTable: 
+  CategoriesTable:
     Description: DynamoDB Table for Categories
     Value: !Ref CategoriesTable
 

--- a/src/products/README.md
+++ b/src/products/README.md
@@ -22,8 +22,8 @@ Displays the service welcome page.
 
 ### GET /products/all
 Returns details on all products.
-### GET /products/id/{productID}
-Returns details on the product identified by `{productID}`.
+### GET /products/id/{productIDs}
+Returns details on the product(s) identified by `{productIDs}`. Multiple product IDs can be specified by separating each product ID by a comma. If a single product ID is specified, a single product will be returned. Otherwise, if multiple product IDs are specified, an array of products will be returned.
 ### GET /products/featured
 Returns details on all featured products. Featured products are those with featured attribute equal to true.
 ### GET /products/category/{categoryName}

--- a/src/products/load_catalog.py
+++ b/src/products/load_catalog.py
@@ -1,0 +1,133 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+'''
+Utility script that can be run locally to load/reload the catalog in DynamoDB tables.
+This script can update either the categories table, products table, or both. Each table
+can also be truncated before loading data when you want to completely replace the table's
+contents.
+
+By default the script will load categories and products from the default location in the
+repo. That is, the corresponding YAML files in the src/products-service/data/ directory.
+You can override the file location on the command-line.
+
+Usage:
+
+python load_catalog.py --categories-table-name CATEGORIES_TABLE_NAME [--categories-file CATEGORIES_FILE] --products-table-name PRODUCTS_TABLE_NAME [--products_file PRODUCTS_FILE] [--truncate]
+
+Where:
+CATEGORIES_TABLE_NAME is the DynamoDB table name for categories
+CATEGORIES_FILE is the location on your local machine where the categories.yaml is located (defaults to src/products-service/data/categories.yaml)
+PRODUCTS_TABLE_NAME is the DynamoDB table name for products
+PRODUCTS_FILE is the location on your local machine where the products.yaml is located (defaults to src/products-service/data/products.yaml)
+
+The script will only truncate (optional) and load the table(s) specified.
+
+Your AWS credentials are discovered from your current environment.
+'''
+
+import sys
+import getopt
+import yaml
+import boto3
+from decimal import Decimal
+
+def truncate_table(table):
+    print('Truncating table...')
+    #get the table keys
+    tableKeyNames = [key.get("AttributeName") for key in table.key_schema]
+
+    #Only retrieve the keys for each item in the table (minimize data transfer)
+    projectionExpression = ", ".join('#' + key for key in tableKeyNames)
+    expressionAttrNames = {'#'+key: key for key in tableKeyNames}
+
+    counter = 0
+    page = table.scan(ProjectionExpression=projectionExpression, ExpressionAttributeNames=expressionAttrNames)
+    with table.batch_writer() as batch:
+        while page["Count"] > 0:
+            counter += page["Count"]
+            # Delete items in batches
+            for itemKeys in page["Items"]:
+                batch.delete_item(Key=itemKeys)
+            # Fetch the next page
+            if 'LastEvaluatedKey' in page:
+                page = table.scan(
+                    ProjectionExpression=projectionExpression, ExpressionAttributeNames=expressionAttrNames,
+                    ExclusiveStartKey=page['LastEvaluatedKey'])
+            else:
+                break
+    print(f"Deleted {counter} items")
+
+if __name__=="__main__":
+    categories_table_name = None
+    categories_file = 'src/products-service/data/categories.yaml'
+    products_table_name = None
+    products_file = 'src/products-service/data/products.yaml'
+    truncate = False
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'h', ['categories-table-name=', 'categories-file=', 'products-table-name=', 'products-file=', 'truncate'])
+    except getopt.GetoptError:
+        print(f'Usage: {sys.argv[0]} --categories-table-name CATEGORIES_TABLE_NAME [--categories-file CATEGORIES_FILE] --products-table-name PRODUCTS_TABLE_NAME [--products_file PRODUCTS_FILE] [--truncate]')
+        sys.exit(2)
+
+    for opt, arg in opts:
+        if opt == '-h':
+            print(f'Usage: {sys.argv[0]} --categories-table-name CATEGORIES_TABLE_NAME [--categories-file CATEGORIES_FILE] --products-table-name PRODUCTS_TABLE_NAME [--products_file PRODUCTS_FILE] [--truncate]')
+            sys.exit()
+        elif opt in ('--categories-table-name'):
+            categories_table_name = arg
+        elif opt in ('-categories-file-name'):
+            categories_file = arg
+        elif opt in ('--products-table-name'):
+            products_table_name = arg
+        elif opt in ('--products-file-name'):
+            products_file = arg
+        elif opt in ('--truncate'):
+            truncate = True
+
+    if not categories_table_name and not products_table_name:
+        print('--categories-table-name and/or --products-table-name are required')
+        print(f'Usage: {sys.argv[0]} --categories-table-name CATEGORIES_TABLE_NAME [--categories-file CATEGORIES_FILE] --products-table-name PRODUCTS_TABLE_NAME [--products_file PRODUCTS_FILE] [--truncate]')
+        sys.exit(1)
+
+    dynamodb = boto3.resource('dynamodb')
+
+    if categories_table_name:
+        print(f'Loading categories from {categories_file} into table {categories_table_name}')
+        table = dynamodb.Table(categories_table_name)
+
+        if truncate:
+            truncate_table(table)
+
+        print(f'Loading categories from {categories_file}')
+        with open(categories_file, 'r') as f:
+            categories = yaml.safe_load(f)
+
+        print(f'Updating categories in table {categories_table_name}')
+        for category in categories:
+            category['id'] = str(category['id'])
+            table.put_item(Item=category)
+
+        print(f'Categories loaded: {len(categories)}')
+
+    if products_table_name:
+        print(f'Loading products from {products_file} into table {products_table_name}')
+        table = dynamodb.Table(products_table_name)
+
+        if truncate:
+            truncate_table(table)
+
+        print(f'Loading products from {products_file}')
+        with open(products_file, 'r') as f:
+            products = yaml.safe_load(f)
+
+        print(f'Updating products in table {products_table_name}')
+        for product in products:
+            if product.get('price'):
+                product['price'] = Decimal(str(product['price']))
+            if product.get('featured'):
+                product['featured'] = str(product['featured']).lower()
+            table.put_item(Item=product)
+
+        print(f'Products loaded: {len(products)}')

--- a/src/products/src/products-service/go.mod
+++ b/src/products/src/products-service/go.mod
@@ -3,7 +3,7 @@ module products
 go 1.15
 
 require (
-	github.com/aws/aws-sdk-go v1.40.4
+	github.com/aws/aws-sdk-go v1.40.38
 	github.com/google/uuid v1.1.5
 	github.com/gorilla/mux v1.8.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/src/products/src/products-service/localdev.go
+++ b/src/products/src/products-service/localdev.go
@@ -102,36 +102,26 @@ func createProductsTable() error {
 				AttributeName: aws.String("id"),
 				KeyType:       aws.String("HASH"),
 			},
-			{
-				AttributeName: aws.String("category"),
-				KeyType:       aws.String("RANGE"),
-			},
 		},
 		BillingMode: aws.String("PAY_PER_REQUEST"),
-		LocalSecondaryIndexes: []*dynamodb.LocalSecondaryIndex{
-			{
-				IndexName: aws.String("id-featured-index"),
-				KeySchema: []*dynamodb.KeySchemaElement{
-					{
-						AttributeName: aws.String("id"),
-						KeyType:       aws.String("HASH"),
-					},
-					{
-						AttributeName: aws.String("featured"),
-						KeyType:       aws.String("RANGE"),
-					},
-				},
-				Projection: &dynamodb.Projection{
-					ProjectionType: aws.String("ALL"),
-				},
-			},
-		},
 		GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{
 			{
 				IndexName: aws.String("category-index"),
 				KeySchema: []*dynamodb.KeySchemaElement{
 					{
 						AttributeName: aws.String("category"),
+						KeyType:       aws.String("HASH"),
+					},
+				},
+				Projection: &dynamodb.Projection{
+					ProjectionType: aws.String("ALL"),
+				},
+			},
+			{
+				IndexName: aws.String("featured-index"),
+				KeySchema: []*dynamodb.KeySchemaElement{
+					{
+						AttributeName: aws.String("featured"),
 						KeyType:       aws.String("HASH"),
 					},
 				},

--- a/src/products/src/products-service/routes.go
+++ b/src/products/src/products-service/routes.go
@@ -32,7 +32,7 @@ var routes = Routes{
 	Route{
 		"ProductShow",
 		"GET",
-		"/products/id/{productID}",
+		"/products/id/{productIDs}",
 		ProductShow,
 	},
 	Route{

--- a/src/web-ui/src/partials/Navigation/Search/Search.vue
+++ b/src/web-ui/src/partials/Navigation/Search/Search.vue
@@ -27,7 +27,7 @@
       <SearchItem
         v-for="result in results"
         :key="result.itemId"
-        :product_id="result.itemId"
+        :product="result.product"
         :experiment="result.experiment"
         :feature="feature"
       />
@@ -46,6 +46,7 @@ import LoadingFallback from '@/components/LoadingFallback/LoadingFallback';
 
 const SearchRepository = RepositoryFactory.get('search');
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
+const ProductsRepository = RepositoryFactory.get('products')
 
 const EXPERIMENT_FEATURE = 'search_results';
 
@@ -88,6 +89,9 @@ export default {
       const { data } = await SearchRepository.searchProducts(val, size);
 
       await this.rerank(data);
+      if (items.length > 0) {
+        await this.lookupProducts(this.results);
+      }
 
       AnalyticsHandler.productSearched(this.user, val, data.length);
     },
@@ -101,6 +105,18 @@ export default {
         this.results = items;
       }
     },
+    async lookupProducts(items) {
+      let itemIds = items.map(item => item.itemId);
+      const { data } = await ProductsRepository.getProduct(itemIds);
+      items.forEach(function (item) {
+        for (var i = 0; i < data.length; i++) {
+          if (item.itemId == data[i].id) {
+            item.product = data[i];
+            break;
+          }
+        }
+      });
+    }
   },
   watch: {
     async searchTerm(val) {

--- a/src/web-ui/src/partials/Navigation/Search/Search.vue
+++ b/src/web-ui/src/partials/Navigation/Search/Search.vue
@@ -89,7 +89,7 @@ export default {
       const { data } = await SearchRepository.searchProducts(val, size);
 
       await this.rerank(data);
-      if (items.length > 0) {
+      if (this.results.length > 0) {
         await this.lookupProducts(this.results);
       }
 
@@ -106,16 +106,14 @@ export default {
       }
     },
     async lookupProducts(items) {
-      let itemIds = items.map(item => item.itemId);
+      const itemIds = items.map(item => item.itemId);
+
       const { data } = await ProductsRepository.getProduct(itemIds);
-      items.forEach(function (item) {
-        for (var i = 0; i < data.length; i++) {
-          if (item.itemId == data[i].id) {
-            item.product = data[i];
-            break;
-          }
-        }
-      });
+
+      this.results = items.map((item) => ({
+        ...item,
+        product: data.find(({id}) => id === item.itemId)
+      }));
     }
   },
   watch: {

--- a/src/web-ui/src/partials/Navigation/Search/SearchItem/SearchItem.vue
+++ b/src/web-ui/src/partials/Navigation/Search/SearchItem/SearchItem.vue
@@ -19,14 +19,11 @@ import { product } from '@/mixins/product';
 export default {
   name: 'SearchItem',
   props: {
-    product_id: { type: String, required: true },
+    product: { type: Object, required: true },
     feature: { type: String, required: true },
     experiment: { type: Object, required: false },
   },
   mixins: [product],
-  created() {
-    this.getProductByID(this.product_id);
-  },
   computed: {
     experimentCorrelationId() {
       return this.experiment?.correlationId;

--- a/src/web-ui/src/repositories/productsRepository.js
+++ b/src/web-ui/src/repositories/productsRepository.js
@@ -22,6 +22,8 @@ export default {
     getProduct(productID) {
         if (!productID || productID.length == 0)
             throw "productID required"
+        if (Array.isArray(productID))
+            productID = productID.join()
         return connection.get(`${resource}/id/${productID}`)
     },
     getProductsByCategory(categoryName) {


### PR DESCRIPTION
*Issue #, if available:*

Closes #101 

*Description of changes:*

- Added ability to request details for multiple products, based on product ID, in a single request to the Products service.
- Refactored the products DDB primary key and indexes so that the DDB BatchGetItem API can be used to efficiently request a batch of items.
- Updated Recommendations service to use the new multi-product GET API to fetch product details in a single call rather than separate calls for each item (optimization).
- Updated search component in the web app to use the new multi-product GET API to fetch product details in a single call rather than separate calls for each item (optimization).
- Added a utility script that can be used to more easily load and reload categories and products in local DDB or AWS DDB from local machine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
