### PR TITLE
Remove unnecessary iam:PassRole permission from WebUiPipleine

### DIFF
--- a/aws/cloudformation-templates/web-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/web-ui-pipeline.yaml
@@ -320,7 +320,6 @@ Resources:
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
-                  - iam:PassRole
               - Resource: !Sub 'arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:retaildemostore-src'
                 Effect: Allow
                 Action:


### PR DESCRIPTION
*Description of changes:*

The `iam:PassRole` permission is only necessary if CodeBuild requires CloudFormation support, which is not the case for this pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
