### PR TITLE
Use json.loads rather than eval in pinpoint SMS lambda

### DIFF
--- a/src/aws-lambda/pinpoint-sms-alerts/pinpoint-sms-alerts.py
+++ b/src/aws-lambda/pinpoint-sms-alerts/pinpoint-sms-alerts.py
@@ -53,7 +53,7 @@ def lambda_handler(event, context):
     pinpoint_app_id = os.environ['pinpoint_app_id']
 
     timestamp =  event['Records'][0]['Sns']['Timestamp']
-    message = eval(event['Records'][0]['Sns']['Message'])
+    message = json.loads(event['Records'][0]['Sns']['Message'])
     originationNumber = message['originationNumber']
     response = message['messageBody'].lower()
     endpointId = originationNumber[1:]


### PR DESCRIPTION
*Description of changes:*

This change uses `json.loads` to parse the JSON string contained in the message field of the SNS event the lambda function receives in the pinpoint SMS lambda.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
