### PR TITLE
Do not regenerate product ID if supplied in new record endpoint

### DIFF
--- a/src/products/src/products-service/repository.go
+++ b/src/products/src/products-service/repository.go
@@ -516,7 +516,9 @@ func RepoUpdateInventoryDelta(product *Product, stockDelta int) error {
 func RepoNewProduct(product *Product) error {
 	log.Printf("RepoNewProduct --> %#v", product)
 
-	product.ID = strings.ToLower(guuuid.New().String())
+	if len(product.ID) == 0 {
+		product.ID = strings.ToLower(guuuid.New().String())
+	}
 	av, err := dynamodbattribute.MarshalMap(product)
 
 	if err != nil {


### PR DESCRIPTION
External applications may want to supply a product ID via the endpoint.
If supplied, we do not overwrite this ID.
Note: duplicates IDs will update the existing record (no checking for duplicates is done).
This change has been tested.

-----
This work was done by the Dae.mn Team. http://dae.mn/ml
Damien.Duff@dae.mn Joe.Major@dae.mn

