### PR TITLE
Added service URLs as outputs of deployment template (#15)

### DIFF
--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -614,3 +614,39 @@ Outputs:
   AlexaSkillEndpointArn:
     Description: Arn of AWS Lambda function that can be a back-end
     Value: !If [DeployAlexaEndpoint, !GetAtt Alexa.Outputs.AlexaSkillEndpointArn, "NotDeployed"]
+
+  ProductsServiceUrl: 
+    Description: Products load balancer URL.
+    Value: !GetAtt Services.Outputs.ProductsServiceUrl
+
+  UsersServiceUrl: 
+    Description: Users load balancer URL.
+    Value: !GetAtt Services.Outputs.UsersServiceUrl
+
+  CartsServiceUrl: 
+    Description: Carts load balancer URL.
+    Value: !GetAtt Services.Outputs.CartsServiceUrl
+
+  OrdersServiceUrl: 
+    Description: Orders load balancer URL.
+    Value: !GetAtt Services.Outputs.OrdersServiceUrl
+
+  LocationServiceUrl:
+    Description: Location load balancer URL.
+    Value: !GetAtt Services.Outputs.LocationServiceUrl
+
+  RecommendationsServiceUrl:
+    Description: Recommendations load balancer URL.
+    Value: !GetAtt Services.Outputs.RecommendationsServiceUrl
+
+  VideosServiceUrl:
+    Description: Videos load balancer URL.
+    Value: !GetAtt Services.Outputs.VideosServiceUrl
+
+  SearchServiceUrl: 
+    Description: Search load balancer URL.
+    Value: !GetAtt Services.Outputs.SearchServiceUrl
+
+  OffersServiceUrl:
+    Description: Offers service load balancer URL.
+    Value: !GetAtt Services.Outputs.OffersServiceUrl


### PR DESCRIPTION
Bring the service domain names to the top level of cloud formation.
This is useful if:
 - we want to make use of the Retail Demo Store CloudFormation as a substack of another solution.
 - we frequently go looking for these URLs for the purposes of testing.

-----
This work was done by the Dae.mn Team. http://dae.mn/ml
Joe.Major@dae.mn
