### PR TITLE
Repo name for notebook was > 64 chars in EE

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -52,7 +52,7 @@ Resources:
   RetailDemoStoreGitHubRepo:
     Type: AWS::SageMaker::CodeRepository
     Properties: 
-      CodeRepositoryName: !Sub '${Uid}-retail-demo-store'
+      CodeRepositoryName: !Sub '${Uid}-demo-store'
       GitConfig: 
         Branch: !Ref GitHubBranch
         RepositoryUrl:  !Sub
@@ -67,7 +67,7 @@ Resources:
       SubnetId: !Ref Subnet1
       SecurityGroupIds:
         - !Ref SecurityGroup
-      DefaultCodeRepository: !Sub '${Uid}-retail-demo-store'
+      DefaultCodeRepository: !Sub '${Uid}-demo-store'
       Tags:
         -
           Key: "Uid"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In Event Engine, repo name was longer than 64 characters, requiring a change in name for the default repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
