### PR TITLE
Change notebook instance to ml.t2.medium

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -62,7 +62,7 @@ Resources:
     Type: AWS::SageMaker::NotebookInstance
     Properties:
       NotebookInstanceName: !Sub ${Uid}
-      InstanceType: "ml.t3.medium"
+      InstanceType: "ml.t2.medium"  # Ensure instance type is supported by all target regions in README before changing
       RoleArn: !GetAtt ExecutionRole.Arn
       SubnetId: !Ref Subnet1
       SecurityGroupIds:


### PR DESCRIPTION
*Issue #, if available:*
Closes #283 

*Description of changes:*

Since the ml.t3.medium SageMaker instance type is not supported across all of the regions and AZs that this project deploys to, switch back to ml.t2.medium which is more broadly supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
