### PR TITLE
Shorten Personalize role name

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -176,7 +176,7 @@ Resources:
                   - iam:PassRole
                   - iam:DetachRolePolicy
                   - iam:DeleteRole
-                Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${Uid}-PersonalizeS3'
+                Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${Uid}-PersS3'
               -
                 Effect: "Allow"
                 Action:

--- a/src/aws-lambda/personalize-pre-create-campaigns/personalize-pre-create-campaigns.py
+++ b/src/aws-lambda/personalize-pre-create-campaigns/personalize-pre-create-campaigns.py
@@ -92,7 +92,7 @@ dataset_group_name_root_offers = 'retaildemooffers-'
 training_config_param_name = 'retaildemostore-training-config'  # ParameterPersonalizeTrainConfig
 training_state_param_name = 'retaildemostore-training-state'
 
-role_name = os.environ.get('Uid') + '-PersonalizeS3'
+role_name = os.environ.get('Uid') + '-PersS3'
 event_tracking_id_param = 'retaildemostore-personalize-event-tracker-id'
 do_deploy_offers_campaign = os.environ['DeployPersonalizedOffersCampaign'].strip().lower() in ['yes', 'true', '1']
 
@@ -396,7 +396,7 @@ def create_personalize_role(role_name):
 def delete_personalize_role():
     try:
         response = iam.detach_role_policy(
-            RoleName=os.environ.get('Uid')+'-PersonalizeS3',
+            RoleName=os.environ.get('Uid')+'-PersS3',
             PolicyArn='arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'
         )
     except ClientError as e:
@@ -406,7 +406,7 @@ def delete_personalize_role():
 
     try:
         response = iam.delete_role(
-            RoleName=os.environ.get('Uid')+'-PersonalizeS3'
+            RoleName=os.environ.get('Uid')+'-PersS3'
         )
     except ClientError as e:
         error_code = e.response['Error']['Code']

--- a/workshop/1-Personalization/1.1-Personalize.ipynb
+++ b/workshop/1-Personalization/1.1-Personalize.ipynb
@@ -982,7 +982,7 @@
    "source": [
     "iam = boto3.client(\"iam\")\n",
     "\n",
-    "role_name = Uid+\"-PersonalizeS3\"\n",
+    "role_name = Uid+\"-PersS3\"\n",
     "assume_role_policy_document = {\n",
     "    \"Version\": \"2012-10-17\",\n",
     "    \"Statement\": [\n",

--- a/workshop/1-Personalization/1.3-Personalize-Cleanup.ipynb
+++ b/workshop/1-Personalization/1.3-Personalize-Cleanup.ipynb
@@ -582,8 +582,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iam.detach_role_policy(RoleName=Uid+\"-PersonalizeS3\", PolicyArn='arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess')\n",
-    "iam.delete_role(RoleName=Uid+\"-PersonalizeS3\")"
+    "iam.detach_role_policy(RoleName=Uid+\"-PersS3\", PolicyArn='arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess')\n",
+    "iam.delete_role(RoleName=Uid+\"-PersS3\")"
    ]
   },
   {

--- a/workshop/1-Personalization/1.4-Personalized-Offers.ipynb
+++ b/workshop/1-Personalization/1.4-Personalized-Offers.ipynb
@@ -699,7 +699,7 @@
    "source": [
     "iam = boto3.client(\"iam\")\n",
     "\n",
-    "role_name = Uid+\"-PersonalizeS3\"\n",
+    "role_name = Uid+\"-PersS3\"\n",
     "assume_role_policy_document = {\n",
     "    \"Version\": \"2012-10-17\",\n",
     "    \"Statement\": [\n",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Shortens the name of the role used for Personalize workshop and resource creation. This reduces the likelihood of the generated name for the role being too long, causing stack deployment failure. This is currently particularly likely when using Retail Demo Store as a substack.
- Renaming of IAM resources and references to said resources in code + notebooks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
