### PR TITLE
Bugfix: Location services deletion (#20)

### DIFF
--- a/src/aws-lambda/location-resource-stack/location-resource-stack.py
+++ b/src/aws-lambda/location-resource-stack/location-resource-stack.py
@@ -143,7 +143,7 @@ def create(event, context):
     logger.info(response)
 
     logger.info("Creation complete.")
-    return
+    return resource_name
 
 
 @helper.update


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently, the custom resource which provisions and manages Amazon Location Service resources through CloudFormation fails to properly delete resources, causing stack deletion to fail on the first attempt. 
- Return resource name from Location Service custom resource to ensure deletion completes as expected. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
