### PR TITLE
Fix SwaggerUI CodeBuild script permission and wait for invalidation

### DIFF
--- a/aws/cloudformation-templates/swagger-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/swagger-ui-pipeline.yaml
@@ -116,8 +116,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - ssm:GetParameters
-                  - 'cloudfront:CreateInvalidation'
                 Resource: "*"
+        - PolicyName: "invalidation"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - 'cloudfront:CreateInvalidation'
+                  - 'cloudfront:GetInvalidation'
+                Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${SwaggerUICDN}
         - PolicyName: "S3"
           PolicyDocument:
             Version: "2012-10-17"

--- a/src/swagger-ui/buildspec.yml
+++ b/src/swagger-ui/buildspec.yml
@@ -4,6 +4,7 @@ env:
 phases:
   build:
     commands:
+      - chmod +x ./src/swagger-ui/*.bash
       - ./src/swagger-ui/copy-spec-files.bash
       - ./src/swagger-ui/generate-services-json-file.bash
       - cat ./src/swagger-ui/services.json
@@ -16,7 +17,9 @@ phases:
       - aws s3 cp --recursive ./specs s3://${SWAGGER_UI_BUCKET_NAME}/specs
       - aws s3 cp --cache-control="max-age=0, no-cache, no-store, must-revalidate" ./index.html s3://${SWAGGER_UI_BUCKET_NAME}/
       - aws s3 cp --cache-control="max-age=0, no-cache, no-store, must-revalidate" ./services.json s3://${SWAGGER_UI_BUCKET_NAME}/
-      - aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DIST_ID} --paths /index.html /services.json
+      - INVALIDATION_ID=`aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DIST_ID} --paths /index.html /services.json --output text --query 'Invalidation.Id'`
+      - aws cloudfront wait invalidation-completed --distribution-id ${CLOUDFRONT_DIST_ID} --id ${INVALIDATION_ID}
+      - echo "CloudFront URL = ${SWAGGER_UI_ROOT_URL}"
 artifacts:
   files:
     - '**/*'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Grant execution permission to the bash script files that Swagger UI CodeBuild project uses
2. Wait for CloudFront Invalidation to complete and print out CloudFront URL


*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
I've deployed and test this change in my own AWS account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
