### PR TITLE
Empty SwaggerUI bucket with a custom resource to not block deletion

### DIFF
--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -13,13 +13,6 @@ Conditions:
   IADRegion: !Equals [!Ref "AWS::Region", "us-east-1"]
 
 Resources:
-
-  # Empties bucket when stack is deleted
-  EmptyStackBucket:
-    Type: Custom::EmptyStackBucket
-    Properties:
-      ServiceToken: !Ref CleanupBucketLambdaArn
-      BucketName: !Ref WebUIBucket
   
   # Web UI infrastructure    
   WebUIBucket:
@@ -28,6 +21,13 @@ Resources:
       AccessControl: Private
       WebsiteConfiguration:
         IndexDocument: index.html
+
+  # Empties bucket when stack is deleted
+  EmptyWebUIBucket:
+    Type: Custom::EmptyStackBucket
+    Properties:
+      ServiceToken: !Ref CleanupBucketLambdaArn
+      BucketName: !Ref WebUIBucket
 
   WebUIBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
@@ -81,6 +81,13 @@ Resources:
       AccessControl: Private
       WebsiteConfiguration:
         IndexDocument: index.html
+
+  # Empties bucket when stack is deleted
+  EmptySwaggerUIBucket:
+    Type: Custom::EmptyStackBucket
+    Properties:
+      ServiceToken: !Ref CleanupBucketLambdaArn
+      BucketName: !Ref SwaggerUIBucket
 
   SwaggerUIBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When deleting the stack, the `cloudfront.yaml` stack cannot be deleted because the `SwaggerUIBucket` isn't empty.

Example log with error:
```
2022-04-04 10:18:02 UTC+0100SwaggerUIBucketDELETE_FAILEDThe bucket you tried to delete is not empty (Service: Amazon S3; Status Code: 409; Error Code: BucketNotEmpty; Request ID: EPFPPXD4MC1EMGMR; S3 Extended Request ID: lXlm2mDYSA/vrEo34MdNIwsWUn3ax16ZAeFzjDYC/5g3B0eUlN3sl5jZKZcEfMASYw98GB5ANbQ=; Proxy: null)
```

This change add a custom resource to empty the bucket during CloudFormation deletion. 



*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

I have deployed the main stack & deleted it. The deletion doesn't stuck with non-empty bucket now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
