### PR TITLE
OpenAPI specs' licenses should be MIT-0

### DIFF
--- a/src/carts/openapi/spec.yaml
+++ b/src/carts/openapi/spec.yaml
@@ -7,7 +7,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Carts

--- a/src/location/openapi/spec.yaml
+++ b/src/location/openapi/spec.yaml
@@ -9,7 +9,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Location

--- a/src/offers/openapi/spec.yaml
+++ b/src/offers/openapi/spec.yaml
@@ -11,7 +11,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Offers

--- a/src/orders/openapi/spec.yaml
+++ b/src/orders/openapi/spec.yaml
@@ -7,7 +7,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Orders

--- a/src/products/openapi/spec.yaml
+++ b/src/products/openapi/spec.yaml
@@ -7,7 +7,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Products

--- a/src/recommendations/openapi/spec.yaml
+++ b/src/recommendations/openapi/spec.yaml
@@ -11,7 +11,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Recommendations

--- a/src/search/openapi/spec.yaml
+++ b/src/search/openapi/spec.yaml
@@ -8,7 +8,7 @@ info:
     
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Search

--- a/src/users/openapi/spec.yaml
+++ b/src/users/openapi/spec.yaml
@@ -15,7 +15,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Users

--- a/src/videos/openapi/spec.yaml
+++ b/src/videos/openapi/spec.yaml
@@ -8,7 +8,7 @@ info:
 
   license: 
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
-    name: Amazon Software License (ASL)
+    name: MIT No Attribution (MIT-0)
 
 tags:
   - name: Streams


### PR DESCRIPTION
*Issue #, if available:* #337

*Description of changes:*
Change all OpenAPI specs' license to MIT-0

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

Started the server locally and tested that it doesn't break anything.
```sh
cd src
docker-compose up --build swagger-ui
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
