### PR TITLE
Makefile for running integration tests

### DIFF
--- a/src/.env.template
+++ b/src/.env.template
@@ -49,3 +49,8 @@ USE_DEFAULT_IVS_STREAMS=true
 
 # Update to match your Evidently project name
 EVIDENTLY_PROJECT_NAME=retaildemostore
+
+# For orders service integration tests
+ORDERS_API_URL=http://localhost:8004
+TEST_ORDER_ID=1
+TEST_USERNAME=user1344

--- a/src/.env.template
+++ b/src/.env.template
@@ -35,6 +35,11 @@ OFFERS_SERVICE_PORT=80
 # PRODUCT_SERVICE_PORT=80
 # OFFERS_SERVICE_HOST=FILL-ME-IN.elb.amazonaws.com
 # OFFERS_SERVICE_PORT=80
+# For products service integration tests
+PRODUCTS_API_URL="http://localhost:8001"
+TEST_PRODUCT_ID="8bffb5fb-624f-48a8-a99f-b8e9c64bbe29"
+TEST_CATEGORY_NAME="tools"
+TEST_CATEGORY_ID="16"
 
 # Search service:
 # Elasticsearch domain settings for local instance

--- a/src/orders/test/integ/requirements.txt
+++ b/src/orders/test/integ/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.1
+python-dotenv
 ../../testing

--- a/src/orders/test/integ/test-orders.py
+++ b/src/orders/test/integ/test-orders.py
@@ -12,7 +12,6 @@ orders_api_url = os.getenv('ORDERS_API_URL')
 
 def test_get_orders_all():
 
-    print(os.environ.items())
     endpoint = "/orders/all"
     integhelpers.get_request_assert(orders_api_url, endpoint, schemas_path)
 

--- a/src/orders/test/integ/test-orders.py
+++ b/src/orders/test/integ/test-orders.py
@@ -1,5 +1,8 @@
 import testhelpers.integ as integhelpers
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 request_bodies_path = integhelpers.absolute_file_path(cwd, "json_request_bodies.json")
@@ -9,6 +12,7 @@ orders_api_url = os.getenv('ORDERS_API_URL')
 
 def test_get_orders_all():
 
+    print(os.environ.items())
     endpoint = "/orders/all"
     integhelpers.get_request_assert(orders_api_url, endpoint, schemas_path)
 

--- a/src/products/test/integ/requirements.txt
+++ b/src/products/test/integ/requirements.txt
@@ -1,2 +1,3 @@
 pytest
+python-dotenv
 ../../testing

--- a/src/products/test/integ/test-products.py
+++ b/src/products/test/integ/test-products.py
@@ -1,5 +1,8 @@
 import testhelpers.integ as integhelpers
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 request_bodies_path = integhelpers.absolute_file_path(cwd, "json_request_bodies.json")

--- a/src/run-tests/Makefile
+++ b/src/run-tests/Makefile
@@ -1,0 +1,15 @@
+.PHONY: test setup venv integ clean
+
+test: integ
+
+setup: venv
+	bash ./install-requirements-integ.sh
+
+venv:
+	test -d venv || (python3 -m venv .venv)
+
+integ: setup
+	bash ./run-tests-integ.sh $(service)
+
+clean:
+	rm -rf .venv

--- a/src/run-tests/README.md
+++ b/src/run-tests/README.md
@@ -1,0 +1,29 @@
+# Running Tests with GNU Make
+The Makefile in this folder allows tests to be ran in bulk (or by service/function) without any additional setup.
+
+Run the below commands in this directory (`src/run-tests`)
+
+## Targets
+### `make`
+
+Runs default target (`test`).
+
+### `make test`
+
+Run all tests of all types. Currently, only integration tests are supported.
+
+### `make setup`
+
+Depends on `venv` target. Installs test requirements inside a virtual environment.
+
+### `make venv`
+
+Create virtual environment.
+
+### `make integ service=`
+
+Depends on `setup` target. Run all integration tests. (Optional: Specify service parameter to run tests for that service only).
+
+### `make clean`
+
+Remove virtual environment.

--- a/src/run-tests/install-requirements-integ.sh
+++ b/src/run-tests/install-requirements-integ.sh
@@ -1,0 +1,17 @@
+source .venv/bin/activate
+
+dir="$PWD"
+home_dir="$(dirname "$dir")"
+cd "$home_dir" || exit
+
+# Find all directories containing tests
+find . -type d  -name 'test' | while read dir; do
+  cd "$dir" || exit
+  # Install requirements. We currently only have integration tests.
+  if [ -f integ/requirements.txt ]; then
+    pip install -r integ/requirements.txt
+  fi
+  cd "$home_dir" || exit
+done
+
+deactivate

--- a/src/run-tests/run-tests-integ.sh
+++ b/src/run-tests/run-tests-integ.sh
@@ -1,0 +1,23 @@
+source .venv/bin/activate
+
+dir="$PWD"
+home_dir="$(dirname "$dir")"
+cd "$home_dir" || exit
+
+: '
+If we have accepted an argument (service name), attempt to change into that directory.
+This ensures we only run tests for that service as requested.
+'
+if [ ! -z "$1" ]; then
+  cd "$1" || { echo "Service does not exist."; exit 1; }
+fi
+
+# Find directories containing integration tests
+find . -type d  -name 'integ' | while read dir; do
+  cd "$dir" || exit
+  find . -type f -name 'test*.py' -exec pytest {} +
+  # Change back into home directory after each set of tests have been run in order to reset process.
+  cd "$home_dir" || exit
+done
+
+deactivate


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Adds a Makefile with targets to setup and run integration tests, either in bulk or by service. The current integration tests (orders and products) have been altered to load in environment variables using dotenv, and the default values for local testing are added to the .env.template file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
