### PR TITLE
Switch to match_bool_prefix queries

### DIFF
--- a/src/search/local_index_products.py
+++ b/src/search/local_index_products.py
@@ -9,7 +9,6 @@
 # When deploying to AWS, products are either indexed by a Lambda function
 # (custom resource) or using the Search workshop notebook.
 
-import json
 import os
 import sys
 import requests

--- a/src/search/openapi/spec.yaml
+++ b/src/search/openapi/spec.yaml
@@ -2,11 +2,11 @@ openapi: '3.0.2'
 info:
   title: Search API
   version: v1
-  description: |- 
-    The Search web service provides a RESTful API for retrieving product information based on a search term. The [Web UI](../../web-ui) makes calls to this service when a user performs a search. 
+  description: |-
+    The Search web service provides a RESTful API for retrieving product information based on a search term. The [Web UI](../../web-ui) makes calls to this service when a user performs a search.
     Internally, this service makes calls to an [Elasticsearch](https://www.elastic.co/) cluster for search results. When deployed on AWS, [Amazon Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/) is used. When deployed locally, a local Elasticsearch node is used for searches.
-    
-  license: 
+
+  license:
     url: https://github.com/aws-samples/retail-demo-store/blob/master/LICENSE
     name: MIT No Attribution (MIT-0)
 
@@ -21,7 +21,7 @@ servers:
       host:
         default: 'localhost'
       port:
-        default: '8006' 
+        default: '8006'
         description: Use the port from ../docker-compose.yml
 paths:
   /search/products:
@@ -59,6 +59,8 @@ paths:
                 $ref: '#/components/schemas/Result'
         '400':
           description: Bad request
+        '404':
+          description: Underlying search index does not exist, most likely because the search workshop has not been completed yet
   /similar/products:
     get:
       tags:
@@ -94,11 +96,13 @@ paths:
                 $ref: '#/components/schemas/Result'
         '400':
           description: Bad request
+        '404':
+          description: Underlying search index does not exist, most likely because the search workshop has not been completed yet
 components:
   schemas:
     Result:
       type: array
-      items: 
+      items:
         type: object
         properties:
           itemId:

--- a/src/search/src/search-service/app.py
+++ b/src/search/src/search-service/app.py
@@ -92,7 +92,7 @@ def index():
     return 'Search Service'
 
 @app.route('/search/products', methods=['GET'])
-def searchProducts():
+def search_products():
     search_term = request.args.get('searchTerm')
     if not search_term:
         raise BadRequest('searchTerm is required')
@@ -108,10 +108,10 @@ def searchProducts():
             "query": {
                 "dis_max" : {
                     "queries" : [
-                        { "wildcard" : { "name" : { "value": '{}*'.format(search_term), "boost": 1.2 }}},
-                        { "term" : { "category" : search_term }},
-                        { "term" : { "style" : search_term }},
-                        { "wildcard" : { "description" : { "value": '{}*'.format(search_term), "boost": 0.6 }}}
+                        { "match_bool_prefix" : { "name" : { "query": search_term, "boost": 1.2 }}},
+                        { "match_bool_prefix" : { "category" : search_term }},
+                        { "match_bool_prefix" : { "style" : search_term }},
+                        { "match_bool_prefix" : { "description" : { "query": search_term, "boost": 0.6 }}}
                     ],
                     "tie_breaker" : 0.7
                 }
@@ -139,7 +139,7 @@ def searchProducts():
         raise BadRequest(message = 'Unhandled error', status_code = 500)
 
 @app.route('/similar/products', methods=['GET'])
-def similarProducts():
+def similar_products():
     product_id = request.args.get('productId')
     if not product_id:
         raise BadRequest('productId is required')


### PR DESCRIPTION
*Issue #, if available:*

Closes #360 

*Description of changes:*

- Change ES queries for `/search/products` endpoint from term and wildcard to match_bool_prefix. This automatically constructs bool query based on terms of query expression and the last term is a prefix query.
- Minor update to OpenAPI spec to include 404 error responses.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

- Deployed update to search service with query changes and tested single and multi-term queries. Multi-term queries now return results as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
