### PR TITLE
Disabling Fenix Commerce for a default deployment

### DIFF
--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -439,7 +439,7 @@ Parameters:
     AllowedValues:
       - 'TRUE'
       - 'FALSE'
-    Default: 'TRUE'
+    Default: 'FALSE'
 
   FenixEnabledCart:
     Type: String
@@ -447,7 +447,7 @@ Parameters:
     AllowedValues:
       - 'TRUE'
       - 'FALSE'
-    Default: 'TRUE'
+    Default: 'FALSE'
 
   FenixEnabledCheckout:
     Type: String
@@ -455,7 +455,7 @@ Parameters:
     AllowedValues:
       - 'TRUE'
       - 'FALSE'
-    Default: 'TRUE'
+    Default: 'FALSE'
 
 Conditions:
   DeploySegmentResources: !Equals


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disabling Fenix for a default deployment

I kept for now the "TRUE/FALSE" for sake of simplicity as it's used directly into the web-ui code (a yes/no would require a translation when going into the ui code) like here:

in src/web-ui/src/public/Checkout.vue
```
  data () {
    return {
      errors: [],
      cart: null,
      order: null,
      showCheckout: false,
      collectionPhone: '',
      previousPageLinkProps: {
        to: '/cart',
        text: 'Back to shopping cart'
      },
      collection: false,
      hasConsentedPhone: false,
      fenixenableCHECKOUT: process.env.VUE_APP_FENIX_ENABLED_CHECKOUT,
    }
```

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
