### PR TITLE
Fix SSM param name

### DIFF
--- a/workshop/3-Experimentation/3.4-Multi-Armed-Bandit-Experiment.ipynb
+++ b/workshop/3-Experimentation/3.4-Multi-Armed-Bandit-Experiment.ipynb
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we need to lookup the Amazon Personalize campaign ARN for product recommendations. This is the campaign that was created in the Personalization workshop."
+    "Next we need to lookup the Amazon Personalize campaign/recommender ARN for product recommendations. This is the campaign/recommender that was created in the Personalization workshop."
    ]
   },
   {
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = ssm.get_parameter(Name = 'retaildemostore-related-products-campaign-arn')\n",
+    "response = ssm.get_parameter(Name = '/retaildemostore/personalize/related-items-arn')\n",
     "\n",
     "inference_arn = response['Parameter']['Value']   # Do Not Change\n",
     "print('Personalize product recommendations ARN: ' + inference_arn)"


### PR DESCRIPTION
*Description of changes:*

- The SSM parameter name was changed when the personalization integration was refactored but the reference in this notebook was missed. 

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

- Tested as part of Immersion Day testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
