### PR TITLE
Update Sagemaker Notebook instance

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -73,7 +73,8 @@ Resources:
     Type: AWS::SageMaker::NotebookInstance
     Properties:
       NotebookInstanceName: !Sub ${Uid}
-      InstanceType: "ml.t2.medium"  # Ensure instance type is supported by all target regions in README before changing
+      InstanceType: "ml.t3.medium"  # Ensure instance type is supported by all target regions in README before changing
+      PlatformIdentifier: "notebook-al2-v2"
       RoleArn: !GetAtt ExecutionRole.Arn
       SubnetId: !Ref Subnet1
       SecurityGroupIds:


### PR DESCRIPTION
- Update instance type to ml.t3.medium
- Update Kernel to Amazon Linux 2 and JupyterLab 3

*Issue #, if available:*

*Description of changes:*
Updating Sagemaker Notebook Instance type to latest kernel (AL2), which contains Python 3.8.  This fixes the warnings displayed when importing boto3 that deprecated support for Python 3.6, which was the included version in AL1.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed updated CF template and tested a number of workshops running on updated Sagemaker Notebook instance.  Tested in both Juypter Notebook and JupyterLab


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
