### PR TITLE
Update Amazon Sagemaker Notebook instance to Amazon Linux 2, JupyterLab 3

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -74,6 +74,7 @@ Resources:
     Properties:
       NotebookInstanceName: !Sub ${Uid}
       InstanceType: "ml.t2.medium"  # Ensure instance type is supported by all target regions in README before changing
+      PlatformIdentifier: "notebook-al2-v2"
       RoleArn: !GetAtt ExecutionRole.Arn
       SubnetId: !Ref Subnet1
       SecurityGroupIds:


### PR DESCRIPTION
- This fixes boto3 warnings in workshops as AL2 conda_python3 image contains Python 3.8

*Issue #, if available:*

*Description of changes:*
Added "PlatformIdentifier: notebook-al2-v2" to notebook CF template

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Executed a number of workshop labs to validate changes and test for issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
