### PR TITLE
Rerank related items PDP

### DIFF
--- a/src/aws-lambda/personalize-pre-create-resources/personalize_pre_create_resources.py
+++ b/src/aws-lambda/personalize-pre-create-resources/personalize_pre_create_resources.py
@@ -235,7 +235,7 @@ dataset_group_confs = [
             },
             {
                 'name': 'retaildemostore-filter-include-categories',
-                'expression': 'INCLUDE ItemID WHERE ITEMS.CATEGORY_L1 IN ($CATEGORIES)',
+                'expression': 'EXCLUDE ItemID WHERE INTERACTIONS.event_type IN ("Purchase") | INCLUDE ItemID WHERE ITEMS.CATEGORY_L1 IN ($CATEGORIES)',
                 'param': '/retaildemostore/personalize/filters/filter-include-categories-arn',
                 'paramDescription': 'Retail Demo Store Filter to Include by Categories Arn Parameter'
             }

--- a/src/web-ui/src/components/DemoGuideBadge/DemoGuideBadge.vue
+++ b/src/web-ui/src/components/DemoGuideBadge/DemoGuideBadge.vue
@@ -70,7 +70,7 @@ export default {
         case Articles.SIMS_RECOMMENDATIONS:
           return 'Learn more about similar item (SIMS) recommendations';
         case Articles.SIMILAR_ITEMS_RECOMMENDATIONS:
-          return 'Learn more about similar items recommendations';
+          return 'Learn more about similar items recommendations with personalized ranking';
         case Articles.ECOMM_CUSTOMERS_WHO_VIEWED_X:
           return 'Learn more about customers who viewed X viewed';
         case Articles.ECOMM_FBT:

--- a/src/web-ui/src/partials/AppModal/DemoGuide/DemoGuideArticle/articles/SimilarItemsRecommendations.vue
+++ b/src/web-ui/src/partials/AppModal/DemoGuide/DemoGuideArticle/articles/SimilarItemsRecommendations.vue
@@ -10,19 +10,26 @@
         rel="noreferrer noopener"
         >Similar-Items</a
       >
+      with
+      <a
+        href="https://docs.aws.amazon.com/personalize/latest/dg/personalized-ranking-recipes.html"
+        target="_blank"
+        rel="noreferrer noopener"
+        >Personalized-Ranking</a
+      >
     </template>
 
     <p>
-      Similar item recommendations help users discover new products or compare existing items in your catalog. Amazon
-      Personalize recommends similar items in real-time, based on user behavior to create unique, relevant experiences
+      Related item recommendations help users discover new products or compare existing items in your catalog. Amazon
+      Personalize recommends related items in real-time, based on user behavior and thematically similar item attributes to create unique, relevant experiences
       for your customers.
     </p>
 
     <p>
-      Pretty simple idea, implemented via a combination of item-item collaborative filtering, basically looking at how people are
-      interacting with particular items, and thematic similarities between items based on their item metadata. This recipe uses
-      state-of-the-art deep learning techniques to strike a balance between collaborative and content filtering to make highly
-      relevant related item recommendations.
+      This user experinece is implemented using the Similar-Items algorithm that considers co-occurrence in interactions data (how often these items appear together across user histories)
+      and thematic similarity (what is similar about the items in your catalog) when making recommendations to better quantify similarity for less popular or new items in
+      your catalog. The product detail page in this demo takes it a step further by using the Personalized-Ranking recipe to rerank related items recommendations for each user. This adds a level of
+      personalization to the user experience.
     </p>
 
     <p>
@@ -31,7 +38,8 @@
 
     <p class="similar-item-recommendations">
       The similar item recommendations use case is implemented in all the product detail pages under the “Compare similar items”
-      carousel widget.
+      carousel widget. The order of items is personalized to each user by leveraging the Personalized-Ranking recipe to reorder
+      related items based on the current user's interest.
     </p>
 
     <ArticleFeature>

--- a/src/web-ui/src/partials/Navigation/Search/Search.vue
+++ b/src/web-ui/src/partials/Navigation/Search/Search.vue
@@ -138,6 +138,7 @@ export default {
       if (val.length > 0) {
         this.isSearching = true;
         this.results = null;
+        this.searchError = null
         try {
           await this.search(val);
         } finally {

--- a/src/web-ui/src/public/ProductDetail.vue
+++ b/src/web-ui/src/public/ProductDetail.vue
@@ -95,7 +95,7 @@ import { getDemoGuideArticleFromPersonalizeARN } from '@/partials/AppModal/DemoG
 import Fenixmaster from '@/components/Fenix/Fenixmaster';
 
 const RecommendationsRepository = RepositoryFactory.get('recommendations');
-const MAX_RECOMMENDATIONS = 6;
+const MAX_RECOMMENDATIONS = 10;
 const EXPERIMENT_FEATURE = 'product_detail_related';
 
 export default {
@@ -215,7 +215,8 @@ export default {
 
       if (response.headers) {
         const experimentName = response.headers['x-experiment-name'];
-        const personalizeRecipe = response.headers['x-personalize-recipe'];
+        // For composite use cases such as this one, we may get more than one recipe (comma delimited). Use the first recipe to lookup demo badge.
+        const personalizeRecipe = response.headers['x-personalize-recipe'] ? response.headers['x-personalize-recipe'].split(',')[0] : null;
 
         if (experimentName) this.experiment = `Active experiment: ${experimentName}`;
         if (personalizeRecipe) this.demoGuideBadgeArticle = getDemoGuideArticleFromPersonalizeARN(personalizeRecipe);

--- a/workshop/1-Personalization/Lab-4-Evaluate-recommendations.ipynb
+++ b/workshop/1-Personalization/Lab-4-Evaluate-recommendations.ipynb
@@ -986,7 +986,7 @@
    "source": [
     "### Include by category filter\n",
     "\n",
-    "The last filter that we will create is one that only includes products within one or more categories. This filter illustrates a dynamic filter where the values in the filter expression are passed in at inference-time."
+    "The last filter that we will create is one that excludes purchased products and only includes products within one or more categories. This filter illustrates a dynamic filter where the values in the filter expression are passed in at inference-time."
    ]
   },
   {
@@ -997,7 +997,7 @@
    "source": [
     "include_category_filter_arn = create_filter(\n",
     "    'retaildemostore-filter-include-categories',\n",
-    "    'INCLUDE ItemID WHERE ITEMS.CATEGORY_L1 IN ($CATEGORIES)'\n",
+    "    'EXCLUDE ItemID WHERE INTERACTIONS.event_type IN (\"Purchase\") | INCLUDE ItemID WHERE ITEMS.CATEGORY_L1 IN ($CATEGORIES)'\n",
     ")"
    ]
   },
@@ -1287,9 +1287,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3.8.6 ('venv': venv)",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1301,7 +1301,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d2ca6edb7b84bab06ec39f802df7b8f7871770e31471df2cbe4279e0e7265b83"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Description of changes:*

- To support a new demo use case, added personalized ranking to the related items on the PDP. This adds personalization to an otherwise non-personalized set of recommendations.
- Modify the Personalize filter used on the PDP to also exclude recently purchased products. Also a demo request.
- Improved auto-complete search results by collapsing on category to improve diversity of recommendations. This resolves an issue with short queries, such as single letter prefix queries, that are populated with so many products that Personalize reanking cannot raise any relevant items. For example, a query for "s" had too many "shirts" and "scarfs" to pushed relevant items such as "speakers" for users interested in electronics. To fix this, the OpenSearch query was modified to collapse on category to ensure that the top hits from all categories were represented in the final result. This allows reranking to find and rerank relevant items to the top of the list.
- Fixed minor issue in the search widget that resets the search error message before performing a search. Otherwise, a prior error message would "stick" after an underlying error condition is resolved.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

- Deployed and tested all changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
