### PR TITLE
Use ml.t3.medium instance type for Sagemaker Notebook

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -58,6 +58,8 @@ Conditions:
   UseDefaultGitHubUser: !Equals
       - !Ref GitHubUser
       - ''
+  # ml.t3.medium instance type not available in all Sydney AZs (https://aws.amazon.com/releasenotes/sagemaker-instance-types-in-sydney-ap-southeast-2/)
+  UseT3InstanceType: !Not [!Equals [!Ref 'AWS::Region', 'ap-southeast-2'] ]
 
 Resources:
   RetailDemoStoreGitHubRepo:
@@ -73,7 +75,7 @@ Resources:
     Type: AWS::SageMaker::NotebookInstance
     Properties:
       NotebookInstanceName: !Sub ${Uid}
-      InstanceType: "ml.t2.medium"  # Ensure instance type is supported by all target regions in README before changing
+      InstanceType: !If [UseT3InstanceType, 'ml.t3.medium', 'ml.t2.medium']  # Ensure instance type is supported by all target regions in README before changing
       PlatformIdentifier: "notebook-al2-v2"
       RoleArn: !GetAtt ExecutionRole.Arn
       SubnetId: !Ref Subnet1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates Notebook CloudFormation script to use ml.t3.medium if supported in region.
The Sydney region supports ml.t3.medium in only two out of three AZs; therefore, will use ml.t2.medium.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Tested deployment in Tokyo, Sydney and Ireland.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
