### PR TITLE
Clarify environment variable usage

### DIFF
--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -900,6 +900,9 @@ Outputs:
         OPENSEARCH_DOMAIN_SCHEME=https
         OPENSEARCH_DOMAIN_HOST="${Base.Outputs.OpenSearchDomainEndpoint}"
         OPENSEARCH_DOMAIN_PORT=9200
+      
+        # Evidently
+        EVIDENTLY_PROJECT_NAME="${Base.Outputs.EvidentlyProjectName}"
 
         # Users service
         AWS_REGION=${AWS::Region}

--- a/scripts/deploy-cloudformation-stacks.sh
+++ b/scripts/deploy-cloudformation-stacks.sh
@@ -15,7 +15,7 @@ set -e
 # The script parses the command line argument and extract these variables:
 # 1. "args" contains an array of arguments (e.g. args[0], args[1], etc.) In this script, we use only 2 arguments (S3_BUCKET, REGION)
 # 2. "pre_create_personalize" contains a boolean value whether "--pre-create-personalize" is presented 
-# 2. "pre_index_elasticsearch" contains a boolean value whether "--pre-index-elasticsearch" is presented
+# 3. "pre_index_elasticsearch" contains a boolean value whether "--pre-index-elasticsearch" is presented
 ########################################################################################################################################
 args=()
 pre_create_personalize=false
@@ -33,18 +33,18 @@ do
         bool=$(echo ${arg:2} | sed s/://g)
         if [ "$bool" == "pre-create-personalize" ]
         then
-            private_s3=true
-            echo Recieved a \"--pre-create-personalize\" flag. Will create personalize resources after deployment
+            pre_create_personalize=true
+            echo Received a \"--pre-create-personalize\" flag. Will create personalize resources after deployment
         elif [ "$bool" == "pre-index-elasticsearch" ]
         then
-            only_cfn_template=true
-            echo Recieved a \"--pre-index-elasticsearch\" flag. Will index ElasticSearch after deployment
+            pre_index_elasticsearch=true
+            echo Received a \"--pre-create-personalize\" flag. Will index ElasticSearch after deployment
         else
             echo Received an unknown flag \"$bool\"
             exit 1
         fi
       else
-        value=$1
+        # value=$1
         shift
         # echo \"$arg\" is flag with value \"$value\"
       fi

--- a/src/README.md
+++ b/src/README.md
@@ -15,7 +15,7 @@ You can find the common environment variables from your deployed stack in the Cl
 ```sh
 aws cloudformation describe-stacks --stack-name retaildemostore \
   --region REGION \
-  --query "Stacks[0].Outputs[?OutputKey=='ExportEnvVarScript'].OutputValue"
+  --query "Stacks[0].Outputs[?OutputKey=='ExportEnvVarScript'].OutputValue" \
   --output text
 ```
 

--- a/src/run-tests/display-environment-variables.py
+++ b/src/run-tests/display-environment-variables.py
@@ -1,0 +1,17 @@
+# This script displays the environment variables that the python tests will use from the src/.env file
+import os
+
+from dotenv import load_dotenv
+load_dotenv()
+
+print("#######################################################")
+print("### Starting integration tests...")
+print("#######################################################")
+print("### List of API URLs in the environment variable from ~/src/.env")
+print("#######################################################")
+print("# PRODUCTS_API_URL = %s" % os.getenv("PRODUCTS_API_URL"))
+print("# USERS_API_URL = %s" % os.getenv("USERS_API_URL"))
+print("# ORDERS_API_URL = %s" % os.getenv("ORDERS_API_URL"))
+print("# RECOMMENDATIONS_API_URL = %s" % os.getenv("RECOMMENDATIONS_API_URL"))
+print("# Empty values will be defaulted to local URL")
+print("########################################")

--- a/src/run-tests/install-requirements-integ.sh
+++ b/src/run-tests/install-requirements-integ.sh
@@ -1,5 +1,7 @@
 source .venv/bin/activate
 
+pip install -r requirements.txt
+
 dir="$PWD"
 home_dir="$(dirname "$dir")"
 cd "$home_dir" || exit

--- a/src/run-tests/requirements.txt
+++ b/src/run-tests/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv

--- a/src/run-tests/run-tests-integ.sh
+++ b/src/run-tests/run-tests-integ.sh
@@ -14,17 +14,8 @@ if [ ! -z "$1" ]; then
   cd "$1" || { echo "Service does not exist."; exit 1; }
 fi
 
-echo "#######################################################"
-echo "### Starting integration tests..."
-echo "#######################################################"
-echo "### List of API URLs in the environment variable"
-echo "#######################################################"
-echo "# PRODUCTS_API_URL = $PRODUCT_API_URL"
-echo "# USERS_API_URL = $USERS_API_URL"
-echo "# ORDERS_API_URL = $ORDERS_API_URL"
-echo "# RECOMMENDATIONS_API_URL = $RECOMMENDATIONS_API_URL"
-echo "# Empty values will be defaulted to local URL"
-echo "########################################"
+# Displaying the environment variables that the python tests will use
+python "$home_dir/run-tests/display-environment-variables.py"
 
 #########################
 ####### Functions #######


### PR DESCRIPTION
*Description of changes:*

Some minor changes:
1. run-tests-integ.sh now prints out the environment variable values, loaded from the .env file, which will be used by the tests
2. deploy-cloudformation-stacks.sh is no longer ignoring the --pre-create-personalize and --pre-create-personalize flags
3. cloudformation now outputs the EVIDENTLY_PROJECT_NAME to allow it to be copied to the .env file when developing locally

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

1. Ran run-tests-integ.sh against local docker services, verified that the correct environment variable values were printed out
2. Ran deploy-cloudformation-stacks.sh and verified that the values of the --pre-create-personalize and --pre-create-personalize were read correctly
3. Deployed cloudformation stack, verified that EVIDENTLY_PROJECT_NAME appeared in the outputs tab.  Ran 'aws cloudformation describe-stacks .. OutputKey=='ExportEnvVarScript' , verified that EVIDENTLY_PROJECT_NAME appeared correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
