### PR TITLE
Amplitude recommend personalize workshop

### DIFF
--- a/generators/datagenerator/output.py
+++ b/generators/datagenerator/output.py
@@ -5,9 +5,6 @@ from datagenerator.segment import SegmentIdentifyEvent, SegmentTrackEvent, Segme
 from datagenerator.amplitude import AmplitudeIdentifyEvent, AmplitudeTrackEvent, AmplitudeSender
 from datagenerator.file import FileEvent
 
-# TODO: Add Personalize output file formatter
-# TODO: Add Amplitude output formatter
-
 class OutputFormatter:
   def __init__(self, timestamp, user, platform, properties, name = None):
     self.event = name

--- a/generators/generate_interactions_personalize.py
+++ b/generators/generate_interactions_personalize.py
@@ -114,6 +114,7 @@ class PersonalizeOutputFileWriter:
                                 timestamp,
                                 discount_context])
 
+# This is a hack to get around numpy nonstandard type serialization to JSON
 def np_encoder(object):
     if isinstance(object, np.generic):
         return object.item()
@@ -215,8 +216,8 @@ def generate_interactions(users_df, products_df):
     if seconds_increment <= 0: raise AssertionError(f"Should never happen: {seconds_increment} <= 0")
 
     print(f'Minimum interactions to generate: {min_interactions}')
-    print(f'Starting timestamp: ({time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(next_timestamp))})')
-    print(f'Ending timestamp: ({time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(LAST_TIMESTAMP))})')
+    print(f'Starting timestamp: {time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(next_timestamp))}')
+    print(f'Ending timestamp: {time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(LAST_TIMESTAMP))}')
     print(f'Seconds increment: {seconds_increment}')
 
     print("Generating interactions... (this will take a few minutes)")
@@ -266,7 +267,7 @@ def generate_interactions(users_df, products_df):
 
     user_category_to_first_prod = {}
 
-    while interactions < min_interactions:
+    while interactions < min_interactions or next_timestamp < LAST_TIMESTAMP:
         if (time.time() > next_update_progress):
             rate = interactions / (time.time() - start_time_progress)
             to_go = (min_interactions - interactions) / rate
@@ -402,6 +403,7 @@ def generate_interactions(users_df, products_df):
                         product=product, 
                         discount_context=discount_context)
                 product_added_count += 1
+                interactions += 1
 
                 if discounted:
                     discounted_product_added_count += 1
@@ -414,6 +416,8 @@ def generate_interactions(users_df, products_df):
                         product=product, 
                         discount_context=discount_context)
                 cart_viewed_count += 1
+                interactions += 1
+
                 if discounted:
                     discounted_cart_viewed_count += 1
 
@@ -425,6 +429,8 @@ def generate_interactions(users_df, products_df):
                         product=product,
                         discount_context=discount_context)
                 checkout_started_count += 1
+                interactions += 1
+
                 if discounted:
                         discounted_checkout_started_count += 1
 
@@ -436,6 +442,8 @@ def generate_interactions(users_df, products_df):
                         product=product,
                         discount_context=discount_context)
                 order_completed_count += 1
+                interactions += 1
+
                 if discounted:
                     discounted_order_completed_count += 1
 

--- a/generators/generate_interactions_personalize.py
+++ b/generators/generate_interactions_personalize.py
@@ -78,7 +78,7 @@ GENDER_ANY = 'Any'
 # The meaning of the below constants is described in the relevant notebook.
 
 # Minimum number of interactions to generate
-min_interactions =  675000 
+min_interactions = 675000 
 
 # Percentages of each event type to generate
 product_added_percent = .08
@@ -214,10 +214,10 @@ def generate_interactions(users_df, products_df):
 
     if seconds_increment <= 0: raise AssertionError(f"Should never happen: {seconds_increment} <= 0")
 
-    print('Minimum interactions to generate: {}'.format(min_interactions))
-    print('Starting timestamp: {} ({})'.format(next_timestamp,
-                                               time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(next_timestamp))))
-    print('Seconds increment: {}'.format(seconds_increment))
+    print(f'Minimum interactions to generate: {min_interactions}')
+    print(f'Starting timestamp: ({time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(next_timestamp))})')
+    print(f'Ending timestamp: ({time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(LAST_TIMESTAMP))})')
+    print(f'Seconds increment: {seconds_increment}')
 
     print("Generating interactions... (this will take a few minutes)")
     interactions = 0
@@ -380,7 +380,7 @@ def generate_interactions(users_df, products_df):
 
             discount_context = 'Yes' if discounted else 'No'
 
-            this_timestamp = next_timestamp + random.randint(1, seconds_increment)
+            this_timestamp = next_timestamp + random.randint(int(seconds_increment), int(seconds_increment * 2))
             ow.event('View',
                     this_timestamp,
                     user,
@@ -395,50 +395,50 @@ def generate_interactions(users_df, products_df):
                 discounted_product_viewed_count += 1
 
             if product_added_count < int(product_viewed_count * product_added_percent):
-                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                this_timestamp += random.randint(int(seconds_increment), int(seconds_increment * 2))
                 ow.event('AddToCart',
                         this_timestamp,
                         user,
                         product=product, 
                         discount_context=discount_context)
-                interactions += 1
+                #interactions += 1
                 product_added_count += 1
 
                 if discounted:
                     discounted_product_added_count += 1
 
             if cart_viewed_count < int(product_viewed_count * cart_viewed_percent):
-                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                this_timestamp += random.randint(int(seconds_increment), int(seconds_increment * 2))
                 ow.event('ViewCart',
                         this_timestamp,
                         user,
                         product=product, 
                         discount_context=discount_context)
-                interactions += 1
+                #interactions += 1
                 cart_viewed_count += 1
                 if discounted:
                     discounted_cart_viewed_count += 1
 
             if checkout_started_count < int(product_viewed_count * checkout_started_percent):
-                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                this_timestamp += random.randint(int(seconds_increment), int(seconds_increment * 2))
                 ow.event('StartCheckout',
                         this_timestamp,
                         user,
                         product=product,
                         discount_context=discount_context)
-                interactions += 1
+                #interactions += 1
                 checkout_started_count += 1
                 if discounted:
                         discounted_checkout_started_count += 1
 
             if order_completed_count < int(product_viewed_count * order_completed_percent):
-                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                this_timestamp += random.randint(int(seconds_increment), int(seconds_increment * 2))
                 ow.event('Purchase',
                         this_timestamp,
                         user,
                         product=product,
                         discount_context=discount_context)
-                interactions += 1
+                #interactions += 1
                 order_completed_count += 1
                 if discounted:
                     discounted_order_completed_count += 1

--- a/generators/generate_interactions_personalize.py
+++ b/generators/generate_interactions_personalize.py
@@ -35,8 +35,12 @@ RANDOM_SEED = 0
 GENERATED_DATA_ROOT = "src/aws-lambda/personalize-pre-create-resources/data"
 
 # Interactions will be generated between these dates
-FIRST_TIMESTAMP = 1591803782  # 2020-06-10, 18:43:02
-LAST_TIMESTAMP = 1599579782  # 2020-09-08, 18:43:02
+
+# set the end time to the start of the script (since we are generating historical data) 
+# this is in epoch time in *seconds*
+LAST_TIMESTAMP = time.time() 
+# generate data 90 days prior to the current time 
+FIRST_TIMESTAMP = LAST_TIMESTAMP - (60*60*24*90) 
 
 # Users are set up with 3 product categories on their personas. If [0.6, 0.25, 0.15] it means
 # 60% of the time they'll choose a product from the first category, etc.
@@ -73,13 +77,45 @@ out_interactions_filename = f"{GENERATED_DATA_ROOT}/interactions.csv"
 
 # Minimum number of interactions to generate
 min_interactions = 675000
-# min_interactions = 50000
 
 # Percentages of each event type to generate
 product_added_percent = .08
 cart_viewed_percent = .05
 checkout_started_percent = .02
 order_completed_percent = .01
+
+class PersonalizeOutputFileWriter:
+    def __init__(self, file_name):
+        f = open(file_name, 'w')
+        self.csv_file = csv.writer(f)
+        # Write the header row
+        self.csv_file.writerow(["ITEM_ID", "USER_ID", "EVENT_TYPE", "TIMESTAMP", "DISCOUNT"])
+
+    def event(self, event_name, timestamp, user, **properties):
+        self.csv_file.writerow([properties['product']['id'],
+                                user['id'],
+                                event_name,
+                                timestamp,
+                                properties['discount_context']])
+
+class AmplitudeOutputFileWriter:
+    def __init__(self, file_name):
+        self.file = open(file_name, 'w')
+
+    def event(self, event_name, timestamp, user, **properties):
+        user_id = f'{user["id"]:0>5}'
+        amplitude_event = {
+            'event_type': event_name,
+            'time': timestamp * 1000,  # Amplitude wants time in ms since the epoch
+            'user_id': user_id,
+            'user_properties': {
+                'name': user['name'],
+                'age': user['age'],
+                'gender': user['gender'],
+                'persona': user['persona']
+            } 
+        }
+        self.file.write(f'{amplitude_event}\n')  # write this in Amplitude JSON event format for S3 import
 
 def generate_user_items(out_users_filename, out_items_filename, in_users_filenames, in_products_filename):
 
@@ -168,221 +204,223 @@ def generate_interactions(out_interactions_filename, users_df, products_df):
 
     print("Writing interactions to: {}".format(out_interactions_filename))
 
-    with open(out_interactions_filename, 'w') as outfile:
-        f = csv.writer(outfile)
-        f.writerow(["ITEM_ID", "USER_ID", "EVENT_TYPE", "TIMESTAMP", "DISCOUNT"])
+    ###############################################################################
+    # TODO: ADD A CMD LINE OPTION TO CONTROL THIS
 
-        category_frequencies = products_df.category.value_counts()
-        category_frequencies /= sum(category_frequencies.values)
+    # Create a file writer
+    ow = AmplitudeOutputFileWriter(out_interactions_filename)
 
-        interaction_product_counts = defaultdict(int)
+    category_frequencies = products_df.category.value_counts()
+    category_frequencies /= sum(category_frequencies.values)
 
-        # Here we build up a list for each category/gender, of product
-        # affinities. The product affinity is keyed by one product,
-        # so we do not end up with exactly PRODUCT_AFFINITY_N sized
-        # cliques. They overlap a little over multiple users
-        # - that is why PRODUCT_AFFINITY_N
-        # can be a little bit lower than a desired clique size.
-        all_categories = products_df.category.unique()
-        product_affinities_bycatgender = {}
-        for category in all_categories:
-            for gender in ['M', 'F']:
-                products_cat = products_df.loc[products_df.category==category]
-                products_cat = products_cat.loc[
-                    products_cat.gender_affinity.isnull()|(products_cat.gender_affinity==gender)].id.values
-                # We ensure that all products have PRODUCT_AFFINITY_N products that lead into it
-                # and PRODUCT_AFFINITY_N products it leads to
-                affinity_matrix = sum([np.roll(np.identity(len(products_cat)), [0, i], [0, 1])
-                                       for i in range(PRODUCT_AFFINITY_N)])
-                np.random.shuffle(affinity_matrix)
-                affinity_matrix = affinity_matrix.T
-                np.random.shuffle(affinity_matrix)
-                affinity_matrix = affinity_matrix.astype(bool)  # use as boolean index
-                affinity_matrix = affinity_matrix | np.identity(len(products_cat), dtype=bool)
+    interaction_product_counts = defaultdict(int)
 
-                product_infinities = [products_cat[row] for row in affinity_matrix]
-                product_affinities_bycatgender[(category, gender)] = {
-                    products_cat[i]: products_df.loc[products_df.id.isin(product_infinities[i])]
-                    for i in range(len(products_cat))}
+    # Here we build up a list for each category/gender, of product
+    # affinities. The product affinity is keyed by one product,
+    # so we do not end up with exactly PRODUCT_AFFINITY_N sized
+    # cliques. They overlap a little over multiple users
+    # - that is why PRODUCT_AFFINITY_N
+    # can be a little bit lower than a desired clique size.
+    all_categories = products_df.category.unique()
+    product_affinities_bycatgender = {}
+    for category in all_categories:
+        for gender in ['M', 'F']:
+            products_cat = products_df.loc[products_df.category==category]
+            products_cat = products_cat.loc[
+                products_cat.gender_affinity.isnull()|(products_cat.gender_affinity==gender)].id.values
+            # We ensure that all products have PRODUCT_AFFINITY_N products that lead into it
+            # and PRODUCT_AFFINITY_N products it leads to
+            affinity_matrix = sum([np.roll(np.identity(len(products_cat)), [0, i], [0, 1])
+                                    for i in range(PRODUCT_AFFINITY_N)])
+            np.random.shuffle(affinity_matrix)
+            affinity_matrix = affinity_matrix.T
+            np.random.shuffle(affinity_matrix)
+            affinity_matrix = affinity_matrix.astype(bool)  # use as boolean index
+            affinity_matrix = affinity_matrix | np.identity(len(products_cat), dtype=bool)
 
-        user_category_to_first_prod = {}
+            product_infinities = [products_cat[row] for row in affinity_matrix]
+            product_affinities_bycatgender[(category, gender)] = {
+                products_cat[i]: products_df.loc[products_df.id.isin(product_infinities[i])]
+                for i in range(len(products_cat))}
 
-        while interactions < min_interactions:
-            if (time.time() > next_update_progress):
-                rate = interactions / (time.time() - start_time_progress)
-                to_go = (min_interactions - interactions) / rate
-                print('Generated {} interactions so far (about {} seconds to go)'.format(interactions, int(to_go)))
-                next_update_progress += PROGRESS_MONITOR_SECONDS_UPDATE
+    user_category_to_first_prod = {}
 
-            # Pick a random user
-            user = users_df.loc[random.randint(0, users_df.shape[0] - 1)]
+    while interactions < min_interactions:
+        if (time.time() > next_update_progress):
+            rate = interactions / (time.time() - start_time_progress)
+            to_go = (min_interactions - interactions) / rate
+            print('Generated {} interactions so far (about {} seconds to go)'.format(interactions, int(to_go)))
+            next_update_progress += PROGRESS_MONITOR_SECONDS_UPDATE
 
-            # Determine category affinity from user's persona
-            persona = user['persona']
-            # If user persona has sub-categories, we will use those sub-categories to find products for users to partake
-            # in interactions with. Otehrwise, we will use the high-level categories.
-            has_subcategories = ':' in user['persona']
-            preferred_categories_and_subcats = persona.split('_')
-            preferred_highlevel_categories = [catstring.split(':')[0] for catstring in preferred_categories_and_subcats]
-            # preferred_styles = [catstring.split(':')[1] for catstring in preferred_categories_and_subcats]
+        # Pick a random user
+        user = users_df.loc[random.randint(0, users_df.shape[0] - 1)]
 
-            p_normalised = (category_affinity_probs * category_frequencies[preferred_highlevel_categories].values)
-            p_normalised /= p_normalised.sum()
-            p = NORMALISE_PER_PRODUCT_WEIGHT * p_normalised + (1-NORMALISE_PER_PRODUCT_WEIGHT) * category_affinity_probs
+        # Determine category affinity from user's persona
+        persona = user['persona']
+        # If user persona has sub-categories, we will use those sub-categories to find products for users to partake
+        # in interactions with. Otehrwise, we will use the high-level categories.
+        has_subcategories = ':' in user['persona']
+        preferred_categories_and_subcats = persona.split('_')
+        preferred_highlevel_categories = [catstring.split(':')[0] for catstring in preferred_categories_and_subcats]
+        # preferred_styles = [catstring.split(':')[1] for catstring in preferred_categories_and_subcats]
 
-            # Select category based on weighted preference of category order.
-            chosen_category_ind = np.random.choice(list(range(len(preferred_categories_and_subcats))), 1, p=p)[0]
-            category = preferred_highlevel_categories[chosen_category_ind]
-            #category_and_subcat = np.random.choice(preferred_categories_and_subcats, 1, p=p)[0]
+        p_normalised = (category_affinity_probs * category_frequencies[preferred_highlevel_categories].values)
+        p_normalised /= p_normalised.sum()
+        p = NORMALISE_PER_PRODUCT_WEIGHT * p_normalised + (1-NORMALISE_PER_PRODUCT_WEIGHT) * category_affinity_probs
 
-            discount_persona = user['discount_persona']
+        # Select category based on weighted preference of category order.
+        chosen_category_ind = np.random.choice(list(range(len(preferred_categories_and_subcats))), 1, p=p)[0]
+        category = preferred_highlevel_categories[chosen_category_ind]
+        #category_and_subcat = np.random.choice(preferred_categories_and_subcats, 1, p=p)[0]
 
-            gender = user['gender']
+        discount_persona = user['discount_persona']
 
-            if has_subcategories:
-                # if there is a preferred style we choose from those products with this style and category
-                # but we ignore gender.
-                # We also do not attempt to keep balance across categories.
-                style = preferred_categories_and_subcats[chosen_category_ind].split(':')[1]
-                cachekey = ('category-style', category, style)
-                prods_subset_df = subsets_cache.get(cachekey)
+        gender = user['gender']
 
-                if prods_subset_df is None:
-                    # Select products from selected category without gender affinity or that match user's gender
-                    prods_subset_df = products_df.loc[(products_df['category']==category) &
-                                                      (products_df['style']==style)]
-                    # Update cache for quicker lookup next time
-                    subsets_cache[cachekey] = prods_subset_df
-            else:
-                # We are only going to use the machinery to keep things balanced
-                # if there is no style appointed on the user preferences.
-                # Here, in order to keep the number of products that are related to a product,
-                # we restrict the size of the set of products that are recommended to an individual
-                # user - in effect, the available subset for a particular category/gender
-                # depends on the first product selected, which is selected as per previous logic
-                # (looking at category affinities and gender)
-                usercat_key = (user['id'], category)  # has this user already selected a "first" product?
-                if usercat_key in user_category_to_first_prod:
-                    # If a first product is already selected, we use the product affinities for that product
-                    # To provide the list of products to select from
-                    first_prod = user_category_to_first_prod[usercat_key]
-                    prods_subset_df = product_affinities_bycatgender[(category, gender)][first_prod]
+        if has_subcategories:
+            # if there is a preferred style we choose from those products with this style and category
+            # but we ignore gender.
+            # We also do not attempt to keep balance across categories.
+            style = preferred_categories_and_subcats[chosen_category_ind].split(':')[1]
+            cachekey = ('category-style', category, style)
+            prods_subset_df = subsets_cache.get(cachekey)
 
-                if not usercat_key in user_category_to_first_prod:
-                    # If the user has not yet selected a first product for this category
-                    # we do it by choosing between all products for gender.
-
-                    # First, check if subset data frame is already cached for category & gender
-                    cachekey = ('category-gender', category, gender)
-                    prods_subset_df = subsets_cache.get(cachekey)
-                    if prods_subset_df is None:
-                        # Select products from selected category without gender affinity or that match user's gender
-                        prods_subset_df = products_df.loc[(products_df['category'] == category) & (
-                                    (products_df['gender_affinity'] == gender) | (products_df['gender_affinity'].isnull()))]
-                        # Update cache
-                        subsets_cache[cachekey] = prods_subset_df
-
-            # Pick a random product from gender filtered subset
-            product = prods_subset_df.sample().iloc[0]
-
-            interaction_product_counts[product.id] += 1
-
-            user_to_product[user['id']].add(product['id'])
+            if prods_subset_df is None:
+                # Select products from selected category without gender affinity or that match user's gender
+                prods_subset_df = products_df.loc[(products_df['category']==category) &
+                                                    (products_df['style']==style)]
+                # Update cache for quicker lookup next time
+                subsets_cache[cachekey] = prods_subset_df
+        else:
+            # We are only going to use the machinery to keep things balanced
+            # if there is no style appointed on the user preferences.
+            # Here, in order to keep the number of products that are related to a product,
+            # we restrict the size of the set of products that are recommended to an individual
+            # user - in effect, the available subset for a particular category/gender
+            # depends on the first product selected, which is selected as per previous logic
+            # (looking at category affinities and gender)
+            usercat_key = (user['id'], category)  # has this user already selected a "first" product?
+            if usercat_key in user_category_to_first_prod:
+                # If a first product is already selected, we use the product affinities for that product
+                # To provide the list of products to select from
+                first_prod = user_category_to_first_prod[usercat_key]
+                prods_subset_df = product_affinities_bycatgender[(category, gender)][first_prod]
 
             if not usercat_key in user_category_to_first_prod:
-                user_category_to_first_prod[usercat_key] = product['id']
+                # If the user has not yet selected a first product for this category
+                # we do it by choosing between all products for gender.
 
-            # Decide if the product the user is interacting with is discounted
-            if discount_persona == 'discount_indifferent':
-                discounted = random.random() < DISCOUNT_PROBABILITY
-            elif discount_persona == 'all_discounts':
+                # First, check if subset data frame is already cached for category & gender
+                cachekey = ('category-gender', category, gender)
+                prods_subset_df = subsets_cache.get(cachekey)
+                if prods_subset_df is None:
+                    # Select products from selected category without gender affinity or that match user's gender
+                    prods_subset_df = products_df.loc[(products_df['category'] == category) & (
+                                (products_df['gender_affinity'] == gender) | (products_df['gender_affinity'].isnull()))]
+                    # Update cache
+                    subsets_cache[cachekey] = prods_subset_df
+
+        # Pick a random product from gender filtered subset
+        product = prods_subset_df.sample().iloc[0]
+
+        interaction_product_counts[product.id] += 1
+
+        user_to_product[user['id']].add(product['id'])
+
+        if not usercat_key in user_category_to_first_prod:
+            user_category_to_first_prod[usercat_key] = product['id']
+
+        # Decide if the product the user is interacting with is discounted
+        if discount_persona == 'discount_indifferent':
+            discounted = random.random() < DISCOUNT_PROBABILITY
+        elif discount_persona == 'all_discounts':
+            discounted = random.random() < DISCOUNT_PROBABILITY_WITH_PREFERENCE
+        elif discount_persona == 'lower_priced_products':
+            if product.price < average_product_price:
                 discounted = random.random() < DISCOUNT_PROBABILITY_WITH_PREFERENCE
-            elif discount_persona == 'lower_priced_products':
-                if product.price < average_product_price:
-                    discounted = random.random() < DISCOUNT_PROBABILITY_WITH_PREFERENCE
-                else:
-                    discounted = random.random() < DISCOUNT_PROBABILITY
             else:
-                raise ValueError(f'Unable to handle discount persona: {discount_persona}')
+                discounted = random.random() < DISCOUNT_PROBABILITY
+        else:
+            raise ValueError(f'Unable to handle discount persona: {discount_persona}')
 
-            num_interaction_sets_to_insert = 1
-            prodcnts = list(interaction_product_counts.values())
-            prodcnts_max = max(prodcnts) if len(prodcnts) > 0 else 0
-            prodcnts_min = min(prodcnts) if len(prodcnts) > 0 else 0
-            prodcnts_avg = sum(prodcnts)/len(prodcnts) if len(prodcnts) > 0 else 0
-            if interaction_product_counts[product.id] * 2 < prodcnts_max:
-                num_interaction_sets_to_insert += 1
-            if interaction_product_counts[product.id] < prodcnts_avg:
-                num_interaction_sets_to_insert += 1
-            if interaction_product_counts[product.id] == prodcnts_min:
-                num_interaction_sets_to_insert += 1
+        num_interaction_sets_to_insert = 1
+        prodcnts = list(interaction_product_counts.values())
+        prodcnts_max = max(prodcnts) if len(prodcnts) > 0 else 0
+        prodcnts_min = min(prodcnts) if len(prodcnts) > 0 else 0
+        prodcnts_avg = sum(prodcnts)/len(prodcnts) if len(prodcnts) > 0 else 0
+        if interaction_product_counts[product.id] * 2 < prodcnts_max:
+            num_interaction_sets_to_insert += 1
+        if interaction_product_counts[product.id] < prodcnts_avg:
+            num_interaction_sets_to_insert += 1
+        if interaction_product_counts[product.id] == prodcnts_min:
+            num_interaction_sets_to_insert += 1
 
-            for _ in range(num_interaction_sets_to_insert):
+        for _ in range(num_interaction_sets_to_insert):
 
-                discount_context = 'Yes' if discounted else 'No'
+            discount_context = 'Yes' if discounted else 'No'
 
-                this_timestamp = next_timestamp + random.randint(1, seconds_increment)
-                f.writerow([product['id'],
-                            user['id'],
-                            'View',
-                            this_timestamp,
-                            discount_context])
+            this_timestamp = next_timestamp + random.randint(1, seconds_increment)
+            ow.event('View',
+                    this_timestamp,
+                    user,
+                    product=product, 
+                    discount_context=discount_context)
 
-                next_timestamp += seconds_increment
-                product_viewed_count += 1
+            next_timestamp += seconds_increment
+            product_viewed_count += 1
+            interactions += 1
+
+            if discounted:
+                discounted_product_viewed_count += 1
+
+            if product_added_count < int(product_viewed_count * product_added_percent):
+                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                ow.event('AddToCart',
+                        this_timestamp,
+                        user,
+                        product=product, 
+                        discount_context=discount_context)
                 interactions += 1
+                product_added_count += 1
 
                 if discounted:
-                    discounted_product_viewed_count += 1
+                    discounted_product_added_count += 1
 
-                if product_added_count < int(product_viewed_count * product_added_percent):
-                    this_timestamp += random.randint(1, int(seconds_increment / 2))
-                    f.writerow([product['id'],
-                                user['id'],
-                                'AddToCart',
-                                this_timestamp,
-                                discount_context])
-                    interactions += 1
-                    product_added_count += 1
+            if cart_viewed_count < int(product_viewed_count * cart_viewed_percent):
+                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                ow.event('ViewCart',
+                        this_timestamp,
+                        user,
+                        product=product, 
+                        discount_context=discount_context)
+                interactions += 1
+                cart_viewed_count += 1
+                if discounted:
+                    discounted_cart_viewed_count += 1
 
-                    if discounted:
-                        discounted_product_added_count += 1
+            if checkout_started_count < int(product_viewed_count * checkout_started_percent):
+                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                ow.event('StartCheckout',
+                        this_timestamp,
+                        user,
+                        product=product,
+                        discount_context=discount_context)
+                interactions += 1
+                checkout_started_count += 1
+                if discounted:
+                        discounted_checkout_started_count += 1
 
-                if cart_viewed_count < int(product_viewed_count * cart_viewed_percent):
-                    this_timestamp += random.randint(1, int(seconds_increment / 2))
-                    f.writerow([product['id'],
-                                user['id'],
-                                'ViewCart',
-                                this_timestamp,
-                                discount_context])
-                    interactions += 1
-                    cart_viewed_count += 1
-                    if discounted:
-                        discounted_cart_viewed_count += 1
-
-                if checkout_started_count < int(product_viewed_count * checkout_started_percent):
-                    this_timestamp += random.randint(1, int(seconds_increment / 2))
-                    f.writerow([product['id'],
-                                user['id'],
-                                'StartCheckout',
-                                this_timestamp,
-                                discount_context])
-                    interactions += 1
-                    checkout_started_count += 1
-                    if discounted:
-                           discounted_checkout_started_count += 1
-
-                if order_completed_count < int(product_viewed_count * order_completed_percent):
-                    this_timestamp += random.randint(1, int(seconds_increment / 2))
-                    f.writerow([product['id'],
-                                user['id'],
-                                'Purchase',
-                                this_timestamp,
-                                discount_context])
-                    interactions += 1
-                    order_completed_count += 1
-                    if discounted:
-                        discounted_order_completed_count += 1
+            if order_completed_count < int(product_viewed_count * order_completed_percent):
+                this_timestamp += random.randint(1, int(seconds_increment / 2))
+                ow.event('Purchase',
+                        this_timestamp,
+                        user,
+                        product=product,
+                        discount_context=discount_context)
+                interactions += 1
+                order_completed_count += 1
+                if discounted:
+                    discounted_order_completed_count += 1
 
     print("Interactions generation done.")
     print(f"Total interactions: {interactions}")

--- a/generators/generate_interactions_personalize.py
+++ b/generators/generate_interactions_personalize.py
@@ -401,7 +401,6 @@ def generate_interactions(users_df, products_df):
                         user,
                         product=product, 
                         discount_context=discount_context)
-                #interactions += 1
                 product_added_count += 1
 
                 if discounted:
@@ -414,7 +413,6 @@ def generate_interactions(users_df, products_df):
                         user,
                         product=product, 
                         discount_context=discount_context)
-                #interactions += 1
                 cart_viewed_count += 1
                 if discounted:
                     discounted_cart_viewed_count += 1
@@ -426,7 +424,6 @@ def generate_interactions(users_df, products_df):
                         user,
                         product=product,
                         discount_context=discount_context)
-                #interactions += 1
                 checkout_started_count += 1
                 if discounted:
                         discounted_checkout_started_count += 1
@@ -438,7 +435,6 @@ def generate_interactions(users_df, products_df):
                         user,
                         product=product,
                         discount_context=discount_context)
-                #interactions += 1
                 order_completed_count += 1
                 if discounted:
                     discounted_order_completed_count += 1

--- a/generators/generate_interactions_personalize.py
+++ b/generators/generate_interactions_personalize.py
@@ -270,7 +270,7 @@ def generate_interactions(users_df, products_df):
         if (time.time() > next_update_progress):
             rate = interactions / (time.time() - start_time_progress)
             to_go = (min_interactions - interactions) / rate
-            print(f'Generated {interactions} interactions so far (about {int(to_go/60)} minutes to go)')
+            print(f'Generated {interactions} interactions so far (about {int(to_go)} seconds to go)')
             next_update_progress += PROGRESS_MONITOR_SECONDS_UPDATE
 
         # Pick a random user

--- a/generators/send_to_amplitude.py
+++ b/generators/send_to_amplitude.py
@@ -1,10 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-import datagenerator
 import json
 import requests
-import yaml
 
 # Amplitude event support
 # This follows the Amplitude V2 HTTP Bulk API spec, here:
@@ -12,7 +10,6 @@ import yaml
 #
 # These classes accept a user, platform, and general event properties and map them 
 # into an Amplitude API compatible represenation.
-
 
 amplitude_interactions_file = 'src/aws-lambda/personalize-pre-create-resources/data/amplitude/interactions.json'
 amplitude_key = 'f6cdf64a6db24778bb9ce82188c19a95'

--- a/generators/send_to_amplitude.py
+++ b/generators/send_to_amplitude.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import datagenerator
+import json
+import requests
+import yaml
+
+# Amplitude event support
+# This follows the Amplitude V2 HTTP Bulk API spec, here:
+# https://help.amplitude.com/hc/en-us/articles/360032842391-HTTP-API-V2
+#
+# These classes accept a user, platform, and general event properties and map them 
+# into an Amplitude API compatible represenation.
+
+
+amplitude_interactions_file = 'src/aws-lambda/personalize-pre-create-resources/data/amplitude/interactions.json'
+amplitude_key = 'f6cdf64a6db24778bb9ce82188c19a95'
+
+class AmplitudeSender:
+  def __init__(self, config):
+    self.config = config # MUST BE:  { 'api_key': <Amplitude API Key> }
+    self.endpoint = 'https://api.amplitude.com/2/httpapi'
+
+  def send_batch(self, events, debug=False):
+    batch_events = {
+      "api_key": self.config['api_key'],
+      "events": events
+    }
+
+    events_str = json.dumps(batch_events, default=lambda x: x.__dict__) 
+    print(f'Batch length bytes: {len(events_str)}')
+    if debug:
+      parsed = json.loads(events_str)
+      #print(f'{json.dumps(parsed, indent=4)}')
+      response = None
+    else:
+      response = requests.post(self.endpoint, 
+        data=events_str)
+      #print(self.config_keys[platform])
+      #print(json.dumps(batch_events, default=lambda x: x.__dict__))
+      print(f'Sent {len(batch_events["events"])} events and got {response}')
+    return response
+
+if __name__ == '__main__':
+    with open(amplitude_interactions_file, 'r') as events_file:
+        sender = AmplitudeSender( { 'api_key': amplitude_key })
+
+        total_event_count = 0
+        send_event_count = 0
+        events = []
+        
+        for event in events_file:
+            events.append(json.loads(event))
+            send_event_count += 1
+            total_event_count += 1
+            if send_event_count == 1000:
+                sender.send_batch(events)
+                print(f'sending {len(events)} events')
+                events = []
+                send_event_count = 0
+
+
+        if len(events) > 0:
+            sender.send_batch(events)
+            print(f'sending {len(events)} events')

--- a/src/web-ui/src/repositories/recommendationsRepository.js
+++ b/src/web-ui/src/repositories/recommendationsRepository.js
@@ -44,6 +44,9 @@ export default {
 
         return connection.get(related, { params: params })
     },
+
+    // TODO:  Add Amplitude Profile API switch here
+
     getRecommendationsForUser(userID, currentItemID, numResults, feature) {
         let params = {
             userID: userID,


### PR DESCRIPTION
*Issue #, if available:*

Getting ready to ship a workshop with Amplitude.  This required retail demo store training data to train the Amplitude Recommend Personalize model.

*Description of changes:*

Modified the personalize interactions generator script to be able to generate events for Personalize and Amplitude.  In the process, discovered that the script had a couple issues, one being that the 90 days of data generated is fixed to three months in 2020, the other that the script did not correctly fill events throughout the whole time span specified, rather enede event generation a month early in the generator time span.

The changes made were to create a range 90 days prior to the date / time the script is run, to refactor the event file writer to generate the Personalize interactions file and the Amplitude interactions file simultaneously.  I also added a check to the event generation loop to keep the loop running until the script generates the minimum number of interactions but also to keep going until the script reaches the LAST_TIME timestamp for the interactions.  A more realistic time spacing between interactions was also added:  this_timestamp += random.randint(int(seconds_increment), int(seconds_increment * 2)) rather than a time between 1 second and 11 seconds.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

Testing was done to make sure the new script behaves like the old one in the retail demo store deployment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
