### PR TITLE
Conditional support for promotional filters

### DIFF
--- a/src/recommendations/src/recommendations-service/app.py
+++ b/src/recommendations/src/recommendations-service/app.py
@@ -454,11 +454,14 @@ def recommendations():
 
     fully_qualify_image_urls = request.args.get('fullyQualifyImageUrls', '0').lower() in [ 'true', 't', '1']
 
-    promotion = {
-        'name': 'promotedItem',
-        'percentPromotedItems': 25,
-        'filterArn': get_parameter_values(promotion_filter_param_name)[0]
-    }
+    promotion = None
+    promotion_filter_arn = get_parameter_values(promotion_filter_param_name)[0]
+    if promotion_filter_arn:
+        promotion = {
+            'name': 'promotedItem',
+            'percentPromotedItems': 25,
+            'filterArn': promotion_filter_arn
+        }
 
     try:
         items, resp_headers = get_products(
@@ -517,11 +520,14 @@ def popular():
 
     fully_qualify_image_urls = request.args.get('fullyQualifyImageUrls', '0').lower() in [ 'true', 't', '1']
 
-    promotion = {
-        'name': 'promotedItem',
-        'percentPromotedItems': 25,
-        'filterArn': get_parameter_values(promotion_filter_no_cstore_param_name)[0]
-    }
+    promotion = None
+    promotion_filter_arn = get_parameter_values(promotion_filter_no_cstore_param_name)[0]
+    if promotion_filter_arn:
+        promotion = {
+            'name': 'promotedItem',
+            'percentPromotedItems': 25,
+            'filterArn': promotion_filter_arn
+        }
 
     try:
         items, resp_headers = get_products(


### PR DESCRIPTION
*Description of changes:*

Conditionally apply promotional filter only when the filter ARN has been set in SSM. Allows for before and after demos with and without promotional filters being applied.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

Tested with deployed instance by changing SSM param for the promotional filter to "NONE" and then to a filter ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
