### PR TITLE
Revert "Enable encryption of Pinpoint SNS Topic for two-way SMS (#410)"

### DIFF
--- a/aws/cloudformation-templates/services/pinpoint-personalize.yaml
+++ b/aws/cloudformation-templates/services/pinpoint-personalize.yaml
@@ -131,7 +131,9 @@ Resources:
     Properties:
       Description: 'Retail Demo Store function that opts in customers to receive sms alerts from Amazon Pinpoint'
       Handler: pinpoint-sms-alerts.lambda_handler
-      Role: !GetAtt PinpointSMSAlertsLambdaExecutionRole.Arn
+      Role: !GetAtt
+        - PinpointSMSAlertsLambdaExecutionRole
+        - Arn
       Code:
         S3Bucket: !Ref ResourceBucket
         S3Key: !Sub '${ResourceBucketRelativePath}aws-lambda/pinpoint-sms-alerts.zip'
@@ -182,66 +184,14 @@ Resources:
                   - mobiletargeting:*
                 Resource: "*"
 
-  PinpointSnsTopicKmsKey:
-    Type: 'AWS::KMS::Key'
-    Properties:
-      Description: Symmetric encryption KMS key for Pinpoint SNS Topic
-      EnableKeyRotation: true
-      PendingWindowInDays: 7
-      KeyPolicy:
-        Version: 2012-10-17
-        Id: sns-key-policy
-        Statement:
-          - Sid: Enable IAM User Permissions
-            Effect: Allow
-            Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Sid: Allow access for Key Administrators
-            Effect: Allow
-            Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/Admin'
-            Action:
-              - kms:Create*
-              - kms:Describe*
-              - kms:Enable*
-              - kms:List*
-              - kms:Put*
-              - kms:Update*
-              - kms:Revoke*
-              - kms:Disable*
-              - kms:Get*
-              - kms:Delete*
-              - kms:TagResource
-              - kms:UntagResource
-              - kms:ScheduleKeyDeletion
-              - kms:CancelKeyDeletion
-            Resource: '*'
-          - Sid: Allow Amazon Pinpoint to use this key
-            Effect: Allow
-            Principal:
-              Service: 'sms-voice.amazonaws.com'
-            Action: 
-              - kms:GenerateDataKey*
-              - kms:Decrypt
-            Resource: '*'
-          - Sid: Allow Amazon SNS to use this key
-            Effect: Allow
-            Principal:
-              Service: sns.amazonaws.com
-            Action: 
-              - kms:GenerateDataKey*
-              - kms:Decrypt     
-            Resource: '*'
-
   PinpointIncomingTextAlertsSNSTopic:
     Type: 'AWS::SNS::Topic'
     Properties:
       Subscription:
-        - Endpoint: !GetAtt PinpointSMSAlertsLambda.Arn            
+        - Endpoint: !GetAtt
+            - PinpointSMSAlertsLambda
+            - Arn
           Protocol: lambda
-      KmsMasterKeyId: !Ref PinpointSnsTopicKmsKey
 
   PinpointSMSAlertsLambdaInvokePermission:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
This reverts commit cc3177402381977a6e817602ae17f1b4b85d59aa since it's causing deployment failure suggesting that one of the principals of PinpointSnsTopicKmsKey is incorrect in an SSO account.

*Issue #, if available:*

*Description of changes:*

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
