### PR TITLE
Enable encryption of Pinpoint SNS Topic for two-way SMS

### DIFF
--- a/aws/cloudformation-templates/services/pinpoint-personalize.yaml
+++ b/aws/cloudformation-templates/services/pinpoint-personalize.yaml
@@ -184,6 +184,39 @@ Resources:
                   - mobiletargeting:*
                 Resource: "*"
 
+  PinpointSnsTopicKmsKey:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: Symmetric encryption KMS key for Pinpoint SNS Topic
+      EnableKeyRotation: true
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: sns-key-policy
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: Allow Amazon Pinpoint to use this key
+            Effect: Allow
+            Principal:
+              Service: 'sms-voice.amazonaws.com'
+            Action: 
+              - kms:GenerateDataKey*
+              - kms:Decrypt
+            Resource: '*'
+          - Sid: Allow Amazon SNS to use this key
+            Effect: Allow
+            Principal:
+              Service: 'sns.amazonaws.com'
+            Action: 
+              - kms:GenerateDataKey*
+              - kms:Decrypt     
+            Resource: '*'
+
   PinpointIncomingTextAlertsSNSTopic:
     Type: 'AWS::SNS::Topic'
     Properties:
@@ -192,6 +225,7 @@ Resources:
             - PinpointSMSAlertsLambda
             - Arn
           Protocol: lambda
+      KmsMasterKeyId: !Ref PinpointSnsTopicKmsKey
 
   PinpointSMSAlertsLambdaInvokePermission:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enables encryption on Pinpoint SNS topic for two-way SMS.  A new KMS key was created with a key policy enabling sns and pinpoint to access.  Previous PR for this erroneously included a policy statement for a role that hadn't been created by the CF template.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed CF into new environment and tested it deletes ok.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
