### PR TITLE
Fix Pinpoint messaging workshop (#413)

### DIFF
--- a/workshop/4-Messaging/4.1-Pinpoint.ipynb
+++ b/workshop/4-Messaging/4.1-Pinpoint.ipynb
@@ -561,12 +561,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Create Recommendations Email Template\n",
-    "\n",
-    "This time when we create the template in Pinpoint, we'll specify the `RecommenderId` for the machine learning model (Amazon Personalize) that we created earlier."
+    "Finally, create the email template."
    ]
   },
   {
@@ -579,7 +579,6 @@
     "    EmailTemplateRequest={\n",
     "        'Subject': 'Retail Demo Store - Products Just for You',\n",
     "        'TemplateDescription': 'Personalized recommendations email template',\n",
-    "        'RecommenderId': recommender_id,\n",
     "        'HtmlPart': html_template,\n",
     "        'TextPart': text_template,\n",
     "        'DefaultSubstitutions': json.dumps({\n",


### PR DESCRIPTION
* Remove reference to recommender_id in Pinpoint messaging workshop

*Issue #, if available:*
#413
*Description of changes:*
Removed reference to recommender_id in Pinpoint messaging workshop
*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Verified by executing relevant notebook snippet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
