### PR TITLE
Remove ACL on S3 buckets and use bucket policy to fix deployment failure

### DIFF
--- a/aws/cloudformation-templates/base/buckets.yaml
+++ b/aws/cloudformation-templates/base/buckets.yaml
@@ -15,7 +15,6 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption: 
@@ -23,6 +22,28 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: true
+
+  S3ServerAccessLogsPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LoggingBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - 's3:PutObject'
+            Effect: Allow
+            Resource: !Join
+              - ''
+              - - 'arn:aws:s3:::'
+                - !Ref LoggingBucket
+                - /*
+            Principal:
+              Service:
+                - "logging.s3.amazonaws.com"
+            Condition:
+              StringEquals: 
+                "aws:SourceAccount": !Ref "AWS::AccountId"
               
   StackBucket:
     Type: AWS::S3::Bucket

--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -22,7 +22,6 @@ Resources:
   WebUIBucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-      AccessControl: Private
       LoggingConfiguration:
         DestinationBucketName: !Ref LoggingBucketName
         LogFilePrefix: webui-logs   
@@ -93,7 +92,6 @@ Resources:
   SwaggerUIBucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-      AccessControl: Private
       LoggingConfiguration:
         DestinationBucketName: !Ref LoggingBucketName
         LogFilePrefix: swaggerui-logs   

--- a/aws/cloudformation-templates/swagger-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/swagger-ui-pipeline.yaml
@@ -188,7 +188,6 @@ Resources:
   ArtifactBucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: Private
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:

--- a/aws/cloudformation-templates/web-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/web-ui-pipeline.yaml
@@ -371,7 +371,6 @@ Resources:
   ArtifactBucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: Private
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:


### PR DESCRIPTION
Fix deployment issue caused by recent rollout of default bucket security settings.

*Issue #, if available:*

*Description of changes:*
Use bucket policy for enabling server access logging instead of ACL.
See https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed to us-east-1 successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
