### PR TITLE
bump python packages in location, offers, videos

### DIFF
--- a/src/location/src/location-service/requirements.txt
+++ b/src/location/src/location-service/requirements.txt
@@ -1,6 +1,6 @@
-Flask==1.0.2
-requests==2.20.0
-boto3==1.12.11
-flask-cors==3.0.9
-itsdangerous==1.1.0
-Jinja2==3.0.3
+Flask==2.3.2
+requests==2.30.0
+boto3==1.26.135
+flask-cors==3.0.10
+itsdangerous==2.1.2
+Jinja2==3.1.2

--- a/src/offers/src/offers-service/requirements.txt
+++ b/src/offers/src/offers-service/requirements.txt
@@ -1,6 +1,6 @@
-Flask==1.0.2
-requests==2.20.0
-boto3==1.12.11
-flask-cors==3.0.9
-itsdangerous==1.1.0
-Jinja2==3.0.3
+Flask==2.3.2
+requests==2.30.0
+boto3==1.26.135
+flask-cors==3.0.10
+itsdangerous==2.1.2
+Jinja2==3.1.2

--- a/src/videos/src/videos-service/requirements.txt
+++ b/src/videos/src/videos-service/requirements.txt
@@ -1,7 +1,7 @@
-Flask==1.0.2
-flask-cors==3.0.9
-boto3==1.14.57
+Flask==2.3.2
+flask-cors==3.0.10
+boto3==1.26.135
 srt
-aws-xray-sdk==2.6.0
-itsdangerous==1.1.0
-Jinja2==3.0.3
+aws-xray-sdk==2.12.0
+itsdangerous==2.1.2
+Jinja2==3.1.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Flask to 2.2.3 and related python packages upgrade in location, offers, videos

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
deploy via pipeline
UI unit testing for videos, location
manual API test for offers (API is limited to get /offers and get /offers/(id) )



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
