### PR TITLE
Fix duplicate pinpoint events

### DIFF
--- a/src/web-ui/src/main.js
+++ b/src/web-ui/src/main.js
@@ -48,8 +48,6 @@ if (AmplifyStore.state.user?.id) {
     }
 }
 
-Analytics.addPluggable(new AWSPinpointProvider());
-
 // Only add Personalize event tracking if configured.
 if (import.meta.env.VITE_PERSONALIZE_TRACKING_ID && import.meta.env.VITE_PERSONALIZE_TRACKING_ID != 'NONE') {
   // Amazon Personalize event tracker.


### PR DESCRIPTION
The Analytics class registers itself with Amplify, which then does a call back to the configure method.   The Analytics configure method adds the AWSPinpointProvider if there  are no pluggables, which there won't be on initialization.  Therefore, the AWSPinpointProvider will always be added by default, and so adding it again, as it has been done in main.js, causes duplicate event processing.

*Issue #, if available:*
[425](https://github.com/aws-samples/retail-demo-store/issues/425)
[423](https://github.com/aws-samples/retail-demo-store/issues/423)

*Description of changes:*
Removed line that explicitely adds the AWSPinpointProvider.  This is unnecessary as it will be done automatically.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Tested locally


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
