### PR TITLE
OriginRequestPolicy name clash fix

### DIFF
--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -87,7 +87,7 @@ Resources:
           CookieBehavior: none
         HeadersConfig: 
           HeaderBehavior: none
-        Name: WebUIOriginRequestPolicy
+        Name: !Ref AWS::StackName
         QueryStringsConfig: 
           QueryStringBehavior: all
 


### PR DESCRIPTION
OriginRequestPolicy has to be uniq accross the AWS Account

*Issue #, if available:*

*Description of changes:*

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
