### PR TITLE
explicitly add routes and error handlers to carts service

### DIFF
--- a/src/carts/src/carts-service/app.py
+++ b/src/carts/src/carts-service/app.py
@@ -4,15 +4,16 @@
 import logging
 import os
 from server import app
+from handlers import handler_bp
+from routes import route_bp
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()])
-
+app.register_blueprint(handler_bp)
+app.register_blueprint(route_bp)
 # Log a message at the start of the script
 app.logger.info('Starting app.py')
 
-import handlers
-import routes
 
 if __name__ == '__main__':
     try:

--- a/src/carts/src/carts-service/handlers.py
+++ b/src/carts/src/carts-service/handlers.py
@@ -1,10 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-from flask import jsonify
+from flask import jsonify,Blueprint
 from werkzeug.exceptions import BadRequest, UnsupportedMediaType, NotFound
 from botocore.exceptions import BotoCoreError
 from server import app
+
+handler_bp = Blueprint('handler_bp', __name__)
 
 @app.errorhandler(BadRequest)
 def handle_bad_request(e):

--- a/src/carts/src/carts-service/routes.py
+++ b/src/carts/src/carts-service/routes.py
@@ -1,10 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-from flask import request, jsonify
+from flask import request, jsonify, Blueprint
 from server import app
 from services import CartService
 from flask import make_response
+
+route_bp = Blueprint('route_bp', __name__)
 
 cart_service = CartService()
 


### PR DESCRIPTION
explicitly add routes and error handlers to carts service using blueprints rather than relying on import side effects

*Issue #, if available:*

*Description of changes:*
Previously routes and error handlers were added to the carts service app using the side effects of import handlers and import routes statements. This means those import statements appeared unused in the app.py script so were picked up by ruff linter. now explicitly adding routes and error handlers by creating blueprints in routes.py and handlers.py and then explicitly registering them in app.py for no unused import statements.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Unit testing with testing scripts and tested by deploying in personal iseng account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
