### PR TITLE
adding ACM Cert Arn as a parameter for WebUICDN CloudFront distribution

### DIFF
--- a/aws/cloudformation-templates/base/_template.yaml
+++ b/aws/cloudformation-templates/base/_template.yaml
@@ -153,6 +153,10 @@ Parameters:
     Default: "nr50Qdu7FM94n2X1GYuhA8cFzyvdYTJ5Qka4XMOd"
     NoEcho: true
 
+  ACMCertificateArn:
+    Type: String
+    Description: ACM Certificate ARN for CloudFront WebUICDN
+
 Resources:
   # Authentication
   Authentication:
@@ -309,6 +313,7 @@ Resources:
       Parameters:
         CleanupBucketLambdaArn: !Ref CleanupBucketLambdaArn
         LoggingBucketName: !GetAtt Buckets.Outputs.LoggingBucketName
+        ACMCertificateArn: !Ref ACMCertificateArn
 
   # Personalize Resources
   Personalize:

--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -11,6 +11,13 @@ Parameters:
   LoggingBucketName:
     Type: String
     Description: S3 Bucket For logging
+  ACMCertificateArn:
+    Type: String
+    Description: ACM Certificate ARN for CloudFront WebUICDN
+
+Conditions:
+  ACMCertificateArnExists: 
+    !Not [!Equals [!Ref ACMCertificateArn, '']]
 
 Resources:
   
@@ -114,6 +121,14 @@ Resources:
           CachePolicyId: !Ref UICachePolicy
           OriginRequestPolicyId: !Ref UIOriginRequestPolicy
           ResponseHeadersPolicyId: 60669652-455b-4ae9-85a4-c4c02393f86c # id for the SimpleCORS AWS Managed response header policies:https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-cors
+        ViewerCertificate:
+          !If 
+            - ACMCertificateArnExists
+            - AcmCertificateArn: !Ref ACMCertificateArn
+              MinimumProtocolVersion: "TLSv1.2_2021"
+              SslSupportMethod: "sni-only"
+            - CloudFrontDefaultCertificate: true
+              MinimumProtocolVersion: "TLSv1"   
 
   # Swagger UI infrastructure
   SwaggerUIBucket:

--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -466,6 +466,10 @@ Parameters:
     Default: 'nr50Qdu7FM94n2X1GYuhA8cFzyvdYTJ5Qka4XMOd'
     NoEcho: true
 
+  ACMCertificateArn:
+    Type: String
+    Description: ACM Certificate ARN for CloudFront WebUICDN
+
 Conditions:
   DeploySegmentResources: !Equals
     - !Ref IncludeSegmentDependencies
@@ -523,6 +527,7 @@ Resources:
         FenixEnabledCart: !Ref FenixEnabledCart
         FenixEnabledCheckout: !Ref FenixEnabledCheckout
         FenixXapiKey: !Ref FenixXapiKey
+        ACMCertificateArn: !Ref ACMCertificateArn
 
   # Services Resources
   Services:

--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -470,7 +470,6 @@ Parameters:
     Default: 'nr50Qdu7FM94n2X1GYuhA8cFzyvdYTJ5Qka4XMOd'
     NoEcho: true
 
-
 Conditions:
   DeploySegmentResources: !Equals
     - !Ref IncludeSegmentDependencies

--- a/aws/cloudformation-templates/template.yaml
+++ b/aws/cloudformation-templates/template.yaml
@@ -69,6 +69,7 @@ Metadata:
           - mParticleS2SApiKey
           - mParticleS2SSecretKey
           - GoogleAnalyticsMeasurementId
+          - ACMCertificateArn
       - Label:
           default: "Fenix Commerce EDD Integration"
         Parameters:
@@ -414,6 +415,10 @@ Parameters:
       Google Analytics Measurement Identifier (optional). If specified, the Google Analytics integration in the web application is activated and
       events are sent to the data stream associated with the Measurement ID.
 
+  ACMCertificateArn:
+    Type: String
+    Description: ACM Certificate ARN for CloudFront WebUICDN (Optional, only needed for custom domain in CloudFront)
+
   FenixZipDetectUrl:
     Type: String
     Description: Fenix Commerce Zipcode Detect URL
@@ -429,7 +434,6 @@ Parameters:
     Type: String
     Description: Fenix Commerce Estimated Delivery Date Endpoint URL
     Default: 'https://platform.api.fenixcommerce.com/awsretaildemostore/fenixdelest/api/v2/deliveryestimates'
-
 
   FenixMonetaryValue:
     Type: String
@@ -466,9 +470,6 @@ Parameters:
     Default: 'nr50Qdu7FM94n2X1GYuhA8cFzyvdYTJ5Qka4XMOd'
     NoEcho: true
 
-  ACMCertificateArn:
-    Type: String
-    Description: ACM Certificate ARN for CloudFront WebUICDN
 
 Conditions:
   DeploySegmentResources: !Equals


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the ACM Cert Arn as a parameter, to enable automated blue-green deployment.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Re-staged bucket then redeployed by adding a ACM cert ARN. Distribution is created with the correct certificate attached.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
