### PR TITLE
Remove preinstall script

### DIFF
--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",


### PR DESCRIPTION
npm-force-resolutions was previously used, added in #390.
It doesn't seem to be used anymore. It is configured by specifying a `resolutions` object in `package.json`. This doesn't exist any more.

This commit removes the preinstall script

*Issue #, if available:*
n/a

*Description of changes:*
Remove pre-install script for web-ui library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
