### PR TITLE
Only show the build status of the master branch in the README badges

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -1,5 +1,9 @@
 name: Build UI
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,9 @@
 name: Ruff
-on: [ push, pull_request ]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A sample retail web application and workshop platform intended as an educational
 
 # Build Status
 
-![Ruff](https://github.com/aws-samples/retail-demo-store/actions/workflows/ruff.yml/badge.svg)
-![UI Build](https://github.com/aws-samples/retail-demo-store/actions/workflows/build-ui.yml/badge.svg)
+![Ruff](https://github.com/aws-samples/retail-demo-store/actions/workflows/ruff.yml/badge.svg?branch=master)
+![UI Build](https://github.com/aws-samples/retail-demo-store/actions/workflows/build-ui.yml/badge.svg?branch=master)
 
 **This project is intended for educational purposes only and not for production use.**
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Currently the status badges in the README display the latest build status, regardless of branch. That means that a failed build of a pull request will cause a failure badge to be displayed.
This PR solves this by:

1. Running the CI jobs on merge to master. 
2. Updating the badge to only display the status of builds of the master branch

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
