### PR TITLE
add ACMCertificateArn to github deploy

### DIFF
--- a/scripts/deploy-cloudformation-stacks.sh
+++ b/scripts/deploy-cloudformation-stacks.sh
@@ -106,6 +106,7 @@ aws cloudformation deploy \
   GitHubToken="" \
   AmplitudeApiKey="" \
   CreateOpenSearchServiceLinkedRole="No" \
+  ACMCertificateArn="" \
   PreCreatePersonalizeResources="${param_personalize}" \
   PreIndexElasticsearch="${param_elasticsearch}"
 


### PR DESCRIPTION
*Issue #, if available:* 
ACMCertificateArn was missing from deploy-cloudformation-stacks.sh

*Description of changes:* 
ACMCertificateArn added to deploy-cloudformation-stacks.sh (used in github actions )

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
