### PR TITLE
reducing Event Bridge resources name length

### DIFF
--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -64,7 +64,7 @@ Resources:
     Type: AWS::CloudFront::OriginAccessControl
     Properties: 
       OriginAccessControlConfig:
-        Name: !Sub 'Retaildemostore-${AWS::Region}'
+        Name: !Sub 'retaildemostore-${AWS::Region}'
         OriginAccessControlOriginType: s3
         SigningBehavior: always
         SigningProtocol: sigv4
@@ -76,7 +76,7 @@ Resources:
         DefaultTTL: 86400
         MaxTTL: 31536000
         MinTTL: 86400
-        Name: !Sub 'Retaildemostore-${AWS::Region}'
+        Name: !Sub 'retaildemostore-${AWS::Region}'
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: none
@@ -94,7 +94,7 @@ Resources:
           CookieBehavior: none
         HeadersConfig: 
           HeaderBehavior: none
-        Name: !Sub 'Retaildemostore-${AWS::Region}'
+        Name: !Sub 'retaildemostore-${AWS::Region}'
         QueryStringsConfig: 
           QueryStringBehavior: all
 

--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -64,7 +64,7 @@ Resources:
     Type: AWS::CloudFront::OriginAccessControl
     Properties: 
       OriginAccessControlConfig:
-        Name: !Ref AWS::StackName
+        Name: !Sub 'Retaildemostore-${AWS::Region}'
         OriginAccessControlOriginType: s3
         SigningBehavior: always
         SigningProtocol: sigv4
@@ -76,7 +76,7 @@ Resources:
         DefaultTTL: 86400
         MaxTTL: 31536000
         MinTTL: 86400
-        Name: !Ref AWS::StackName
+        Name: !Sub 'Retaildemostore-${AWS::Region}'
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: none
@@ -94,7 +94,7 @@ Resources:
           CookieBehavior: none
         HeadersConfig: 
           HeaderBehavior: none
-        Name: !Ref AWS::StackName
+        Name: !Sub 'Retaildemostore-${AWS::Region}'
         QueryStringsConfig: 
           QueryStringBehavior: all
 

--- a/aws/cloudformation-templates/base/event-driven.yaml
+++ b/aws/cloudformation-templates/base/event-driven.yaml
@@ -13,7 +13,7 @@ Resources:
   EventBus:
     Type: AWS::Events::EventBus
     Properties:
-      Name: !Sub "${Uid}-eventbus"
+      Name: !Sub "${Uid}-bus"
 
   CatchAllRule:
     Type: AWS::Events::Rule
@@ -32,7 +32,7 @@ Resources:
   CatchAllEventsLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "${Uid}-events-log"
+      LogGroupName: !Sub "${Uid}-log"
       RetentionInDays: 120
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
@@ -65,7 +65,7 @@ Resources:
   EventArchive:
     Type: AWS::Events::Archive
     Properties:
-      ArchiveName: !Sub "${Uid}-event-archive"
+      ArchiveName: !Sub "${Uid}-arch"
       RetentionDays: 120
       SourceArn: !GetAtt EventBus.Arn
       Description: "Holds a 120 day archive of events from the Retail Demo store event bus"
@@ -89,7 +89,7 @@ Outputs:
     Description: "The name of the EventBridge event bus"
     Value: !Ref EventBus
     Export:
-      Name: !Sub "${Uid}-eventbus"
+      Name: !Sub "${Uid}-bus"
   SSMParameterForEventBus:
     Description: "SSM Parameter storing the EventBridge event bus name for services to use"
     Value: !Ref SSMParamForEventBus


### PR DESCRIPTION
when using a nested cfn template, names are too long (fixes error expected maxLength: 48, actual: xx)

*Issue #, if available:*
When using a nested template, resource name in Event Bridge are too long

```
EventArchive	CREATE_FAILED
Properties validation failed for resource EventArchive with message: #/ArchiveName: expected maxLength: 48, actual: 54

```
*Description of changes:*
workaround fix reducing the name length

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
