### PR TITLE
Add Custom error response to Cloudfront distribution to allow page refresh

### DIFF
--- a/aws/cloudformation-templates/base/cloudfront.yaml
+++ b/aws/cloudformation-templates/base/cloudfront.yaml
@@ -106,6 +106,10 @@ Resources:
       DistributionConfig:
         Enabled: true
         Comment: !Sub 'Retail Demo Store CDN for ${WebUIBucket}'
+        CustomErrorResponses:
+          -  ErrorCode: 403
+             ResponseCode: 200
+             ResponsePagePath: /index.html
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
         HttpVersion: http2and3


### PR DESCRIPTION

*Issue #, if available:*
#456
*Description of changes:*
Created custom error response to intercept 403 errors and convert into a 200 /index.html.  This allows you to perform a page refresh, that currently doesn't work as the frontend is an SPA.
*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Tested cloudfront deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
