### PR TITLE
Bump python3.7 to python3.12

### DIFF
--- a/aws/cloudformation-templates/cleanup-bucket.yaml
+++ b/aws/cloudformation-templates/cleanup-bucket.yaml
@@ -42,7 +42,7 @@ Resources:
             cfnresponse.send(event, context, responseStatus, responseData)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 300
       Role: !GetAtt CleanupBucketLambdaExecutionRole.Arn
 

--- a/aws/cloudformation-templates/services/_template.yaml
+++ b/aws/cloudformation-templates/services/_template.yaml
@@ -61,7 +61,7 @@ Parameters:
 
   IdentityPoolId:
     Type: String
-    
+
   Subnets:
     Type: String
 
@@ -136,11 +136,11 @@ Parameters:
   EvidentlyProjectName:
     Type: String
     Description: Evidently project name
-    
+
   LoggingBucketName:
     Type: String
     Description: S3 Bucket For logging
-  
+
   LambdaVpcSecurityGroup:
     Type: String
 
@@ -214,7 +214,7 @@ Resources:
         ImageRootUrl: !Ref ImageRootUrl
         EvidentlyProjectName: !Ref EvidentlyProjectName
         LoggingBucketName: !Ref LoggingBucketName
-        
+
   CartsService:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -249,7 +249,7 @@ Resources:
         ImageRootUrl: !Ref ImageRootUrl
         EvidentlyProjectName: !Ref EvidentlyProjectName
         LoggingBucketName: !Ref LoggingBucketName
-        
+
   OrdersService:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -282,7 +282,7 @@ Resources:
         ImageRootUrl: !Ref ImageRootUrl
         EvidentlyProjectName: !Ref EvidentlyProjectName
         LoggingBucketName: !Ref LoggingBucketName
-        
+
   SearchService:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -450,7 +450,7 @@ Resources:
         ImageRootUrl: !Ref ImageRootUrl
         EvidentlyProjectName: !Ref EvidentlyProjectName
         LoggingBucketName: !Ref LoggingBucketName
-        
+
   # Pinpoint personalized messaging customization
   PinpointPersonalize:
     Type: AWS::CloudFormation::Stack
@@ -520,7 +520,7 @@ Resources:
             cfnresponse.send(event, context, responseStatus, responseData)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 30
       Role: !GetAtt DeleteRepositoryLambdaExecutionRole.Arn
 
@@ -565,7 +565,7 @@ Outputs:
   UsersServiceUrl:
     Description: Users load balancer URL.
     Value: !GetAtt UsersService.Outputs.ServiceUrl
-  
+
   UsersServiceELBListener:
     Description: Users Service ELB Arn
     Value: !GetAtt UsersService.Outputs.ServiceELBListener

--- a/aws/cloudformation-templates/web-ui-pipeline.yaml
+++ b/aws/cloudformation-templates/web-ui-pipeline.yaml
@@ -226,7 +226,7 @@ Resources:
             cfnresponse.send(event, context, response_status, response_data)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 900
       Role: !GetAtt CopyImagesLambdaExecutionRole.Arn
 
@@ -234,13 +234,13 @@ Resources:
     Type: Custom::CopyImagesToWebUI
     Properties:
       ServiceToken: !GetAtt CopyImagesLambdaFunction.Arn
-      SourceBucket: 
+      SourceBucket:
           !If [
             CustomResourceBucketImages,
             !Ref ResourceBucketImages,
             !Ref ResourceBucket
           ]
-      SourceBucketPath: 
+      SourceBucketPath:
           !If [
             CustomResourceBucketImages,
             !Ref ResourceBucketImagesPrefix,
@@ -296,7 +296,7 @@ Resources:
                     - !Sub arn:${AWS::Partition}:s3:::${ResourceBucket}
                     - !Sub arn:${AWS::Partition}:s3:::${WebUIBucketName}
                     - !Sub arn:${AWS::Partition}:s3:::${WebUIBucketName}/*
-            
+
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -383,13 +383,13 @@ Resources:
         Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !Ref LoggingBucketName
-        LogFilePrefix: artifactui-logs  
-      BucketEncryption: 
+        LogFilePrefix: artifactui-logs
+      BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: true
-             
+
   # Empties bucket when stack is deleted
   EmptyArtifactBucket:
     Type: Custom::EmptyArtifactBucket
@@ -485,7 +485,7 @@ Resources:
           - Name: FENIX_ENABLED_CHECKOUT
             Value: !Ref FenixEnabledCheckout
           - Name: FENIX_X_API_KEY
-            Value: !Ref FenixXapiKey  
+            Value: !Ref FenixXapiKey
           - Name: BEDROCK_PRODUCT_PERSONALIZATION
             Value: !Ref BedrockProductPersonalization
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'


### PR DESCRIPTION
*Description of changes:*

Support for python 3.7 was recently dropped from AWS Lambda. This was causing deployments to fail for 3 functions that still used python3.7 as the runtime. This PR updates the runtime to the latest supported version, python3.12. 

There are other functions that use the 3.8, 3.9, 3.10, and 3.11 runtimes that also need to be upgraded but those aren't addressed in this PR since they are supported and to keep the surface area of this urgent PR small.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

Tested a full deployment and delete deployment. Succeeded without errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
