### PR TITLE
offers file not properly copied from base_url

### DIFF
--- a/src/aws-lambda/personalize-pre-create-resources/personalize_pre_create_resources.py
+++ b/src/aws-lambda/personalize-pre-create-resources/personalize_pre_create_resources.py
@@ -64,7 +64,7 @@ offer_interactions_filename = bucket_path + "offer_interactions.csv"
 filename_items, _ = urllib.request.urlretrieve( base_url + 'csvs/items.csv' , '/tmp/items.csv')
 filename_users, _ = urllib.request.urlretrieve( base_url + 'csvs/users.csv' , '/tmp/users.csv')
 filename_interactions, _ = urllib.request.urlretrieve( base_url + 'csvs/interactions.csv' , '/tmp/interactions.csv')
-filename_offer_interactions, _ = urllib.request.urlretrieve( base_url + 'csvs/interactions.csv' , '/tmp/offer_interactions.csv')
+filename_offer_interactions, _ = urllib.request.urlretrieve( base_url + 'csvs/offer_interactions.csv' , '/tmp/offer_interactions.csv')
 
 # upload these files to the S3 stack bucket where personalize will have the right s3 policies
 s3 = boto3.client('s3')


### PR DESCRIPTION
*Issue #, if available:*
personalize solution fail with
Dataset has fewer than 1000 interactions after filtering by event type: OfferConverted

*Description of changes:*
offer_interactions.csv was not copied in the pre-create-personalize

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
