### PR TITLE
fix: typo in get_env.sh

### DIFF
--- a/src/web-ui/gen_env.sh
+++ b/src/web-ui/gen_env.sh
@@ -9,7 +9,7 @@ set -e
 # Delete .env if it exists
 [ -e ".env" ] && rm .env
 
-printf 'VITE_API_GATEWAY=$s\n' "$API_GATEWAY_URL" >> .env
+printf 'VITE_API_GATEWAY=%s\n' "$API_GATEWAY_URL" >> .env
 printf 'VITE_AWS_REGION=%s\n' "$DEPLOYED_REGION" >> .env
 printf 'VITE_AWS_IDENTITY_POOL_ID=%s\n' "$COGNITO_IDENTITY_POOL_ID" >> .env
 printf 'VITE_AWS_USER_POOL_ID=%s\n' "$COGNITO_USER_POOL_ID" >> .env


### PR DESCRIPTION
*Description of changes:*
Fixes typo that is breaking the frontend.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed to fresh AWS account from scratch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
