### PR TITLE
CloudWatch Logs Resource Policy size Fix

### DIFF
--- a/aws/cloudformation-templates/room-generator.yaml
+++ b/aws/cloudformation-templates/room-generator.yaml
@@ -1670,7 +1670,7 @@ Resources:
   PrepareProductDataSfnLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/sfn/${AWS::StackName}-PrepareProductData
+      LogGroupName: !Sub /aws/vendedlogs/${AWS::StackName}-PrepareProductData
 
   PrepareProductDataStateMachine:
     Type: AWS::StepFunctions::StateMachine


### PR DESCRIPTION
*Issue #, if available:*
detected in couple of place:
```
2024-08-29 02:40:36 UTC+0100
PrepareProductDataStateMachine
CREATE_FAILED	
Resource handler returned message: "Invalid Logging Configuration: The CloudWatch Logs Resource Policy size was exceeded. We suggest prefixing your CloudWatch log group name with /aws/vendedlogs/states/. (Service: AWSStepFunctions; Status Code: 400; Error Code: InvalidLoggingConfiguration; Request ID: 11e1fbc6-75c6-4d01-8457-477d692c9063; Proxy: null)" (RequestToken: 7058b8c7-f28c-db59-39ed-2d821358a8a3, HandlerErrorCode: InvalidRequest)
```

*Description of changes:*
implemented recommendation from https://docs.aws.amazon.com/step-functions/latest/dg/bp-cwl.html

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
just a deploy with room makeover on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
