### PR TITLE
Update `get_all` Method in db.py to Retrieve All Items from DynamoDB table

### DIFF
--- a/src/products/src/products_service/db.py
+++ b/src/products/src/products_service/db.py
@@ -112,8 +112,13 @@ class DynamoBase(ABC):
             return response['Responses'][self.table.name]
     
     def get_all(self):
+        items = []
         response = self.table.scan()
-        return response['Items'] if 'Items' in response else []
+        while 'LastEvaluatedKey' in response:
+            items.extend(response['Items'])
+            response = self.table.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
+        items.extend(response['Items'])
+        return items
 
     def upsert(self, item):
         self.table.put_item(Item=item)


### PR DESCRIPTION
This update modifies the `get_all` method to ensure that all items from the DynamoDB table are retrieved during a scan operation.

*Issue #, if available:*
#639 

*Description of changes:*
Update `get_all` Method in `db.py` to Retrieve All Items from DynamoDB Table

*Reason for Change:*
 - This update modifies the get_all method in the db.py file to ensure all items from the DynamoDB table are retrieved during a scan operation.
 - It addresses an issue in Lab 4 of the `Personalization` workshop, where discrepancies between reranked and unranked product lists occur due to incomplete data retrieval.

*Updated `get_all` method:*

```
def get_all(self):
    items = []
    response = self.table.scan()
    while 'LastEvaluatedKey' in response:
        items.extend(response['Items'])
        response = self.table.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
    items.extend(response['Items'])
    return items
```
- Context:
In Lab 4, `unranked_product_ids` are pulled from the `featured` items table, subsequently used to obtain a reranked list of products from "all" products via AWS Personalize. The existing `get_all` method's use of DynamoDB table scan operation only retrieves a limited subset of items by default, thus the reranked list may contain fewer items than the unranked list.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

*Test:*
```
all_products_resp = requests.get('http://{}/products/all'.format(products_service_instance))

all_products = all_products_resp.json()
print(len(all_products))
```
Output is `2465` representing all products.

- Further tests were performed to ensure that both reranked and unranked lists now contain the same number of items when fetched for side-by-side comparison in Lab 4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
