### PR TITLE
fix for Policy document length breaking Cloudwatch Logs

### DIFF
--- a/aws/cloudformation-templates/apigateway-deploy.yaml
+++ b/aws/cloudformation-templates/apigateway-deploy.yaml
@@ -24,4 +24,4 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 30
-      LogGroupName: !Sub "/${AWS::StackName}/APIAccessLogs"
+      LogGroupName: !Sub /aws/vendedlogs/${AWS::StackName}/APIAccessLogs


### PR DESCRIPTION
*Issue #, if available:*

deploy can fail with
```
Cannot enable logging. Policy document length breaking Cloudwatch Logs Constraints, either < 1 or > 5120 (Service: AmazonApiGatewayV2; Status Code: 400;
```

*Description of changes:*

similar change to #625 for the main apigateway

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
