### PR TITLE
fix the link for local development instructions in `recommendations` service README

### DIFF
--- a/src/recommendations/README.md
+++ b/src/recommendations/README.md
@@ -10,7 +10,7 @@ When deployed to AWS, CodePipeline is used to build and deploy the Recommendatio
 
 ## Local Development
 
-The Recommendations service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](../) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
+The Recommendations service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
 
 ```console
 foo@bar:~$ docker compose up --build recommendations


### PR DESCRIPTION
*Issue #, if available:*
#651

*Description of changes:*

changed the link for the instructions from `(../)` to `(https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md)`

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
