### PR TITLE
update the link for local development instructions in `orders` README

### DIFF
--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -6,7 +6,7 @@ When deployed to AWS, CodePipeline is used to build and deploy the Orders servic
 
 ## Local Development
 
-The Orders service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](../) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
+The Orders service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
 
 ```console
 foo@bar:~$ docker-compose up --build orders


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

The link for the local development instructions is updated to https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
