### PR TITLE
update the link for local development instructions in `location`  README

### DIFF
--- a/src/location/README.md
+++ b/src/location/README.md
@@ -9,7 +9,7 @@ This service has two APIs. Check Swagger UI for the API details.
 
 ## Local Development
 
-The location service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](../) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
+The location service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md) for details. **From the `../src` directory**, run the following command to build and deploy the service locally.
 
 ```console
 foo@bar:~$ docker compose up --build location


### PR DESCRIPTION
…e README

*Issue #, if available:*

*Description of changes:*

The link for local development instructions in the README is updated to https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
