### PR TITLE
update the link for local development instructions in `web-ui` README

### DIFF
--- a/src/web-ui/README.md
+++ b/src/web-ui/README.md
@@ -15,7 +15,7 @@ To get your local Web UI container to make calls to other Retail Demo Store web 
 5. In the "Build logs" tab, scroll down through the build log output until you see the output for the `cat .env` command. You should see a block of several lines that start with `VITE_...`. These lines represent the environment variables used when building the Web UI assets when deployed to S3. Select all of these lines (except the variables with `***` as their values--these are resolved as system parameters) with your mouse and copy them to your clipboard. Alternatively, if you only want to connect to some Retail Demo Store services in ECS and others running locally, just copy the lines that you need for remote services.
 6. Open your local `.env` file and paste over the top of the lines you selected. There is already a [.env.template](.env.template) file with examples of what this would look like.
 
-Once your `.env` is setup, run Docker Compose **from the `../src` directory** as described in the [local development instructions](../) to build and run the Web UI container locally.
+Once your `.env` is setup, run Docker Compose **from the `../src` directory** as described in the [local development instructions](https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md) to build and run the Web UI container locally.
 
 ```console
 foo@bar:~$ docker compose up --build web-ui

--- a/src/web-ui/README.md
+++ b/src/web-ui/README.md
@@ -4,7 +4,7 @@ When deployed to AWS, CodePipeline is used to build and deploy the Retail Demo S
 
 ## Local Development
 
-The Web UI service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](../) for details. Note that you still must first deploy the Retail Demo Store project to AWS to satisfy resource dependencies.
+The Web UI service can be built and run locally (in Docker) using Docker Compose. See the [local development instructions](https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md) for details. Note that you still must first deploy the Retail Demo Store project to AWS to satisfy resource dependencies.
 
 To get your local Web UI container to make calls to other Retail Demo Store web services (either running locally in Docker or in ECS on AWS or a combination of the two) and AWS resources such as Cognito, Pinpoint, or a Personalize Event Tracker, you will need to copy the environment variables in the [.env](./env) file on your local system to match your desired configuration. If you want your local instance of web-ui to connect to resources running in your AWS account, follow these steps to get up and running quickly.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The link for the local development instructions in the README is updated to https://github.com/aws-samples/retail-demo-store/blob/master/docs/Deployment/local-development/0-local-development-instructions.md

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
