### PR TITLE
Upgrade diffusers dependency to 0.31.0 to fix import error from huggingface_hub

### DIFF
--- a/src/roomgenerator/model/code/requirements.txt
+++ b/src/roomgenerator/model/code/requirements.txt
@@ -1,4 +1,4 @@
-diffusers==0.26.3
+diffusers==0.31.0
 transformers
 accelerate
 datasets


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Bump diffusers library to current latest version (0.31.0) as huggingface_hub removed cached_download, resulting in an import error that breaks the room makeover demo

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
