### PR TITLE
Downgrade diffusers to v0.29.2 to fix dependency error

### DIFF
--- a/src/roomgenerator/model/code/requirements.txt
+++ b/src/roomgenerator/model/code/requirements.txt
@@ -1,4 +1,4 @@
-diffusers==0.31.0
+diffusers==0.29.2
 transformers
 accelerate
 datasets


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Downgraded diffusers to version that didn't cause a dependency issue with transformers library, but is recent enough to not use cached_download in huggingface_hub which has been removed.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed to us-east-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
