### PR TITLE
Update PlatformIdentifier for SageMaker notebook from al2-v2 to al2-v3

### DIFF
--- a/aws/cloudformation-templates/base/notebook.yaml
+++ b/aws/cloudformation-templates/base/notebook.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       NotebookInstanceName: !Sub ${Uid}
       InstanceType: !If [UseT3InstanceType, 'ml.t3.medium', 'ml.t2.medium']  # Ensure instance type is supported by all target regions in README before changing
-      PlatformIdentifier: "notebook-al2-v2"
+      PlatformIdentifier: "notebook-al2-v3"
       RoleArn: !GetAtt ExecutionRole.Arn
       SubnetId: !Ref Subnet1
       SecurityGroupIds:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As per https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-al2.html.  Notebook instances running on the JupyterLab 1 and JupyterLab 3 platforms will reach end of support on June 30, 2025.  Upgrading platform identifier to al2-v3

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*
Deployed and tested notebook in us-east-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
