### PR TITLE
Remove golang installation in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,17 +12,13 @@ phases:
       python: 3.12
     commands:
       - echo Entered the install phase...
-      - yum -y install git python3 golang
+      - yum -y install git python3
       - yum -y update ca-certificates
       - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
       - python get-pip.py
       - python -m venv retailstore/env
       - . retailstore/env/bin/activate
       - pip install pip --upgrade
-      - go get github.com/aws/aws-lambda-go/lambda
-      - go get github.com/aws/aws-lambda-go/cfn
-      - go get github.com/aws/aws-sdk-go
-      - go get gopkg.in/yaml.v2
   build:
     commands:
       - python -V


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Golang was still being installed as part of the buildspec that is used to stage the codebase.  Golang is no longer used in the codebase, and this installation would occasionally fail.

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
