### PR TITLE
Update service Dockerfile's to use Python 3.11 image

### DIFF
--- a/src/offers/Dockerfile
+++ b/src/offers/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/s5z3t2n9/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm
 
 COPY /src/offers-service /app
 

--- a/src/recommendations/Dockerfile
+++ b/src/recommendations/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/s5z3t2n9/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm
 
 WORKDIR /app
 

--- a/src/videos/Dockerfile
+++ b/src/videos/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/s5z3t2n9/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
*Issue #, if available:*
Code Build is failing due to old python 3.8 docker image being used for video and recommendations service.

*Description of changes:*
Updated Docker files for services using 3.8 slim image

*Description of testing performed to validate your changes (required if pull request includes CloudFormation or source code changes):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
